### PR TITLE
Add optional third parameter to route: `name`

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -89,9 +89,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var hashParams = _ref$hashParams === undefined ? {} : _ref$hashParams;
 	  var _ref$referrer = _ref.referrer;
 	  var referrer = _ref$referrer === undefined ? '' : _ref$referrer;
+	  var _ref$name = _ref.name;
+	  var name = _ref$name === undefined ? '' : _ref$name;
 	  return {
 	    type: SET_PAGE,
-	    payload: { url: url, urlParams: urlParams, queryParams: queryParams, hashParams: hashParams, referrer: referrer }
+	    payload: { url: url, urlParams: urlParams, queryParams: queryParams, hashParams: hashParams, referrer: referrer, name: name }
 	  };
 	};
 
@@ -115,7 +117,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var referrer = _ref2$referrer === undefined ? '' : _ref2$referrer;
 	  return {
 	    type: NAVIGATE_TO_URL,
-	    payload: { method: method, pathName: pathName, queryParams: queryParams, hashParams: hashParams, bodyParams: bodyParams, referrer: referrer }
+	    payload: {
+	      method: method,
+	      pathName: pathName,
+	      queryParams: queryParams,
+	      hashParams: hashParams,
+	      bodyParams: bodyParams,
+	      referrer: referrer
+	    }
 	  };
 	};
 

--- a/components.js
+++ b/components.js
@@ -198,7 +198,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return;
 	      }
 
-	      console.log(_this2.props.onClick);
 	      _this2.props.onClick(e);
 	      if (e.defaultPrevented) {
 	        return;

--- a/lib/modules/actions.js
+++ b/lib/modules/actions.js
@@ -7,9 +7,15 @@ export const NAVIGATE_TO_URL = 'PLATFORM__NAVIGATE_TO_URL';
 export const SET_SHELL = 'PLATFORM__SET_SHELL';
 export const REROUTE_PAGE = 'PLATFORM__REROUTE_PAGE';
 
-export const setPage = (url, { urlParams={}, queryParams={}, hashParams={}, referrer='' }={}) => ({
+export const setPage = (url, {
+  urlParams={},
+  queryParams={},
+  hashParams={},
+  referrer='',
+  name=''
+}={}) => ({
   type: SET_PAGE,
-  payload: { url, urlParams, queryParams, hashParams, referrer },
+  payload: { url, urlParams, queryParams, hashParams, referrer, name },
 });
 
 export const gotoPageIndex = pageIndex => ({
@@ -28,7 +34,14 @@ export const navigateToUrl = (
   }={}
 ) => ({
   type: NAVIGATE_TO_URL,
-  payload: { method, pathName, queryParams, hashParams, bodyParams, referrer },
+  payload: {
+    method,
+    pathName,
+    queryParams,
+    hashParams,
+    bodyParams,
+    referrer,
+  },
 });
 
 export const setShell = shell => ({ type: SET_SHELL, shell });

--- a/lib/modules/navigationMiddleware.js
+++ b/lib/modules/navigationMiddleware.js
@@ -10,7 +10,7 @@ export default {
         const { dispatch, getState } = store;
 
         for (let route of routes) {
-          const [url, handler] = route;
+          const [url, handler, name] = route;
           const reg = pathToRegex(url);
           const result = reg.exec(pathName);
 
@@ -21,11 +21,13 @@ export default {
             }), {});
 
             if (method === METHODS.GET) {
+              console.log('dispatching with name', name);
               dispatch(actions.setPage(pathName, {
                 urlParams,
                 queryParams,
                 hashParams,
                 referrer,
+                name,
               }));
             }
 
@@ -36,7 +38,8 @@ export default {
               hashParams,
               bodyParams,
               dispatch,
-              getState
+              getState,
+              name,
             );
 
             return next(h[method].bind(h));

--- a/lib/modules/router.js
+++ b/lib/modules/router.js
@@ -9,12 +9,13 @@ export const METHODS = {
 };
 
 export class BaseHandler {
-  constructor(originalUrl, urlParams, queryParams, hashParams, bodyParams, dispatch, getState) {
+  constructor(originalUrl, urlParams, queryParams, hashParams, bodyParams, dispatch, getState, name) {
     this.originalUrl = originalUrl;
     this.urlParams = urlParams;
     this.queryParams = queryParams;
     this.hashParams = hashParams;
     this.bodyParams = bodyParams;
+    this.name = name;
   }
 };
 

--- a/navigationMiddleware.js
+++ b/navigationMiddleware.js
@@ -106,10 +106,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	              var _loop = function _loop() {
 	                var route = _step.value;
 
-	                var _route = _slicedToArray(route, 2);
+	                var _route = _slicedToArray(route, 3);
 
 	                var url = _route[0];
 	                var handler = _route[1];
+	                var name = _route[2];
 
 	                var reg = (0, _pathToRegexp2.default)(url);
 	                var result = reg.exec(pathName);
@@ -120,15 +121,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	                  }, {});
 
 	                  if (method === _router.METHODS.GET) {
+	                    console.log('dispatching with name', name);
 	                    dispatch(actions.setPage(pathName, {
 	                      urlParams: urlParams,
 	                      queryParams: queryParams,
 	                      hashParams: hashParams,
-	                      referrer: referrer
+	                      referrer: referrer,
+	                      name: name
 	                    }));
 	                  }
 
-	                  var h = new handler(pathName, urlParams, queryParams, hashParams, bodyParams, dispatch, getState);
+	                  var h = new handler(pathName, urlParams, queryParams, hashParams, bodyParams, dispatch, getState, name);
 
 	                  return {
 	                    v: next(h[method].bind(h))

--- a/router.js
+++ b/router.js
@@ -78,7 +78,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  DELETE: 'delete'
 	};
 
-	var BaseHandler = exports.BaseHandler = function BaseHandler(originalUrl, urlParams, queryParams, hashParams, bodyParams, dispatch, getState) {
+	var BaseHandler = exports.BaseHandler = function BaseHandler(originalUrl, urlParams, queryParams, hashParams, bodyParams, dispatch, getState, name) {
 	  _classCallCheck(this, BaseHandler);
 
 	  this.originalUrl = originalUrl;
@@ -86,6 +86,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  this.queryParams = queryParams;
 	  this.hashParams = hashParams;
 	  this.bodyParams = bodyParams;
+	  this.name = name;
 	};
 
 	;


### PR DESCRIPTION
This `name` will be sent along with SET_PAGE requests.

Useful for things like page tracking requests; we send different data based on the type of page, which may have several different routes (for example, the event data's `target` is a `link` if you're on a comment page, or a `subreddit` if you're on a subreddit listing page, etc.)

👓 @nramadas @schwers 
