### PR TITLE
Remove invalid form methods

### DIFF
--- a/lib/modules/components.js
+++ b/lib/modules/components.js
@@ -177,7 +177,7 @@ const getValues = form => {
 export class _Form extends React.Component {
   static propTypes = {
     action: T.string.isRequired,
-    method: T.oneOf([METHODS.POST, METHODS.PUT, METHODS.DELETE, METHODS.PATCH]),
+    method: T.oneOf([METHODS.POST, METHODS.GET]),
     className: T.string,
     style: T.object,
     onSubmit: T.func,


### PR DESCRIPTION
According to the [html spec](https://www.w3.org/TR/html401/interact/forms.html#adef-method), only GETs and POSTs are valid http actions for forms.
