### PR TITLE
Fixes to platform's navigation

### DIFF
--- a/Server.js
+++ b/Server.js
@@ -223,6 +223,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	  }();
 
+	  // set up server routes before setting up shared routes
+	  getServerRouter(router);
+
 	  var _iteratorNormalCompletion = true;
 	  var _didIteratorError = false;
 	  var _iteratorError = undefined;
@@ -262,6 +265,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 	      }
 	    }
+
+	    // hook up all the middleware to the koa instance
 	  } catch (err) {
 	    _didIteratorError = true;
 	    _iteratorError = err;
@@ -277,7 +282,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	  }
 
-	  getServerRouter(router);
 	  preRouteServerMiddleware.forEach(function (m) {
 	    return server.use(m);
 	  });

--- a/actions.js
+++ b/actions.js
@@ -89,24 +89,32 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 	};
 
-	var gotoPageIndex = exports.gotoPageIndex = function gotoPageIndex(pageIndex) {
-	  return {
-	    type: GOTO_PAGE_INDEX,
-	    payload: { pageIndex: pageIndex }
-	  };
-	};
-
-	var navigateToUrl = exports.navigateToUrl = function navigateToUrl(method, pathName) {
+	var gotoPageIndex = exports.gotoPageIndex = function gotoPageIndex(pageIndex, pathName) {
 	  var _ref2 = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
 
 	  var _ref2$queryParams = _ref2.queryParams;
 	  var queryParams = _ref2$queryParams === undefined ? {} : _ref2$queryParams;
 	  var _ref2$hashParams = _ref2.hashParams;
 	  var hashParams = _ref2$hashParams === undefined ? {} : _ref2$hashParams;
-	  var _ref2$bodyParams = _ref2.bodyParams;
-	  var bodyParams = _ref2$bodyParams === undefined ? {} : _ref2$bodyParams;
 	  var _ref2$referrer = _ref2.referrer;
 	  var referrer = _ref2$referrer === undefined ? '' : _ref2$referrer;
+	  return {
+	    type: GOTO_PAGE_INDEX,
+	    payload: { pageIndex: pageIndex, pathName: pathName, queryParams: queryParams, hashParams: hashParams, referrer: referrer }
+	  };
+	};
+
+	var navigateToUrl = exports.navigateToUrl = function navigateToUrl(method, pathName) {
+	  var _ref3 = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+
+	  var _ref3$queryParams = _ref3.queryParams;
+	  var queryParams = _ref3$queryParams === undefined ? {} : _ref3$queryParams;
+	  var _ref3$hashParams = _ref3.hashParams;
+	  var hashParams = _ref3$hashParams === undefined ? {} : _ref3$hashParams;
+	  var _ref3$bodyParams = _ref3.bodyParams;
+	  var bodyParams = _ref3$bodyParams === undefined ? {} : _ref3$bodyParams;
+	  var _ref3$referrer = _ref3.referrer;
+	  var referrer = _ref3$referrer === undefined ? '' : _ref3$referrer;
 	  return {
 	    type: NAVIGATE_TO_URL,
 	    payload: { method: method, pathName: pathName, queryParams: queryParams, hashParams: hashParams, bodyParams: bodyParams, referrer: referrer }
@@ -119,7 +127,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var reroutePage = exports.reroutePage = function reroutePage() {
 	  return function () {
-	    var _ref3 = _asyncToGenerator(regeneratorRuntime.mark(function _callee(dispatch, getState) {
+	    var _ref4 = _asyncToGenerator(regeneratorRuntime.mark(function _callee(dispatch, getState) {
 	      var currentPage;
 	      return regeneratorRuntime.wrap(function _callee$(_context) {
 	        while (1) {
@@ -143,15 +151,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }, _callee, undefined);
 	    }));
 
-	    return function (_x3, _x4) {
-	      return _ref3.apply(this, arguments);
+	    return function (_x4, _x5) {
+	      return _ref4.apply(this, arguments);
 	    };
 	  }();
 	};
 
 	var activateClient = exports.activateClient = function activateClient() {
 	  return function () {
-	    var _ref4 = _asyncToGenerator(regeneratorRuntime.mark(function _callee2(dispatch, getState) {
+	    var _ref5 = _asyncToGenerator(regeneratorRuntime.mark(function _callee2(dispatch, getState) {
 	      var _getState, platform;
 
 	      return regeneratorRuntime.wrap(function _callee2$(_context2) {
@@ -181,8 +189,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }, _callee2, undefined);
 	    }));
 
-	    return function (_x5, _x6) {
-	      return _ref4.apply(this, arguments);
+	    return function (_x6, _x7) {
+	      return _ref5.apply(this, arguments);
 	    };
 	  }();
 	};

--- a/components.js
+++ b/components.js
@@ -370,8 +370,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      _this3.props.navigateToPage(url, queryParams);
 	    }, _temp3), _possibleConstructorReturn(_this3, _ret3);
-	  } // intended to supplied by connect
-
+	  }
 
 	  _createClass(_LinkHijacker, [{
 	    key: 'extractValidPath',
@@ -614,9 +613,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	        var currentQuery = (0, _pageUtils.extractQuery)(self.location.search);
 	        var currentHash = {}; // TODO: address how hashes are displayed
 	        var pageIndex = -1;
+	        var hist = {};
 
 	        for (var i = _this7.props.history.length - 1; i >= 0; i--) {
-	          var hist = _this7.props.history[i];
+	          hist = _this7.props.history[i];
 	          if (hist.url === pathname && (0, _lang.isEqual)(hist.queryParams, currentQuery)) {
 	            pageIndex = i;
 	            break;
@@ -624,7 +624,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 
 	        if (pageIndex > -1) {
-	          _this7.props.gotoPageIndex(pageIndex);
+	          var _hist = hist;
+	          var url = _hist.url;
+	          var queryParams = _hist.queryParams;
+	          var hashParams = _hist.hashParams;
+	          var urlParams = _hist.urlParams;
+	          var referrer = _hist.referrer;
+
+	          _this7.props.gotoPageIndex(pageIndex, url, { queryParams: queryParams, hashParams: hashParams, urlParams: urlParams, referrer: referrer });
 	        } else {
 	          // can't find the url, just navigate
 	          _this7.props.navigateToPage(pathname, currentQuery, currentHash);
@@ -689,8 +696,8 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var urlDispatcher = function urlDispatcher(dispatch) {
 	  return {
-	    gotoPageIndex: function gotoPageIndex(index) {
-	      return dispatch(navigationActions.gotoPageIndex(index));
+	    gotoPageIndex: function gotoPageIndex(index, url, data) {
+	      return dispatch(navigationActions.gotoPageIndex(index, url, data));
 	    },
 	    navigateToPage: function navigateToPage(url, queryParams, hashParams) {
 	      return dispatch(navigationActions.navigateToUrl(_router.METHODS.GET, url, { queryParams: queryParams, hashParams: hashParams }));

--- a/components.js
+++ b/components.js
@@ -441,7 +441,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            if (!values[el.name]) {
 	              values[el.name] = [];
 	            }
-	            if (el.value) {
+	            if (el.checked) {
 	              values[el.name].push(el.value);
 	            }
 	            break;

--- a/createTest.js
+++ b/createTest.js
@@ -7,7 +7,7 @@
 		exports["createTest.js"] = factory(require("@r/middleware"), require("react"), require("redux"), require("react-redux"), require("./navigationMiddleware.js"), require("./reducer.js"), require("chai"), require("sinon"), require("sinon-chai"), require("chai-enzyme"), require("enzyme"), require("jsdom"));
 	else
 		root["createTest.js"] = factory(root["@r/middleware"], root["react"], root["redux"], root["react-redux"], root["./navigationMiddleware.js"], root["./reducer.js"], root["chai"], root["sinon"], root["sinon-chai"], root["chai-enzyme"], root["enzyme"], root["jsdom"]);
-})(this, function(__WEBPACK_EXTERNAL_MODULE_1__, __WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_4__, __WEBPACK_EXTERNAL_MODULE_5__, __WEBPACK_EXTERNAL_MODULE_6__, __WEBPACK_EXTERNAL_MODULE_7__, __WEBPACK_EXTERNAL_MODULE_316__, __WEBPACK_EXTERNAL_MODULE_317__, __WEBPACK_EXTERNAL_MODULE_318__, __WEBPACK_EXTERNAL_MODULE_319__, __WEBPACK_EXTERNAL_MODULE_320__, __WEBPACK_EXTERNAL_MODULE_321__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE_1__, __WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_4__, __WEBPACK_EXTERNAL_MODULE_5__, __WEBPACK_EXTERNAL_MODULE_6__, __WEBPACK_EXTERNAL_MODULE_7__, __WEBPACK_EXTERNAL_MODULE_315__, __WEBPACK_EXTERNAL_MODULE_316__, __WEBPACK_EXTERNAL_MODULE_317__, __WEBPACK_EXTERNAL_MODULE_318__, __WEBPACK_EXTERNAL_MODULE_319__, __WEBPACK_EXTERNAL_MODULE_320__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -66,25 +66,25 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	__webpack_require__(18);
 
-	var _chai = __webpack_require__(316);
+	var _chai = __webpack_require__(315);
 
 	var _chai2 = _interopRequireDefault(_chai);
 
-	var _sinon = __webpack_require__(317);
+	var _sinon = __webpack_require__(316);
 
 	var _sinon2 = _interopRequireDefault(_sinon);
 
-	var _sinonChai = __webpack_require__(318);
+	var _sinonChai = __webpack_require__(317);
 
 	var _sinonChai2 = _interopRequireDefault(_sinonChai);
 
-	var _chaiEnzyme = __webpack_require__(319);
+	var _chaiEnzyme = __webpack_require__(318);
 
 	var _chaiEnzyme2 = _interopRequireDefault(_chaiEnzyme);
 
-	var _enzyme = __webpack_require__(320);
+	var _enzyme = __webpack_require__(319);
 
-	var _jsdom = __webpack_require__(321);
+	var _jsdom = __webpack_require__(320);
 
 	var _jsdom2 = _interopRequireDefault(_jsdom);
 
@@ -248,11 +248,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	__webpack_require__(19);
 
-	__webpack_require__(311);
+	__webpack_require__(310);
 
 	// Should be removed in the next major release:
 
-	__webpack_require__(313);
+	__webpack_require__(312);
 
 	if (global._babelPolyfill) {
 	  throw new Error("only one instance of babel-polyfill is allowed");
@@ -305,23 +305,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	__webpack_require__(102);
 	__webpack_require__(104);
 	__webpack_require__(106);
+	__webpack_require__(109);
 	__webpack_require__(110);
 	__webpack_require__(111);
 	__webpack_require__(112);
-	__webpack_require__(113);
+	__webpack_require__(114);
 	__webpack_require__(115);
 	__webpack_require__(116);
 	__webpack_require__(117);
 	__webpack_require__(118);
 	__webpack_require__(119);
 	__webpack_require__(120);
-	__webpack_require__(121);
+	__webpack_require__(122);
 	__webpack_require__(123);
 	__webpack_require__(124);
-	__webpack_require__(125);
+	__webpack_require__(126);
 	__webpack_require__(127);
 	__webpack_require__(128);
-	__webpack_require__(129);
+	__webpack_require__(130);
 	__webpack_require__(131);
 	__webpack_require__(132);
 	__webpack_require__(133);
@@ -335,13 +336,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	__webpack_require__(141);
 	__webpack_require__(142);
 	__webpack_require__(143);
-	__webpack_require__(144);
+	__webpack_require__(148);
 	__webpack_require__(149);
-	__webpack_require__(150);
+	__webpack_require__(153);
 	__webpack_require__(154);
 	__webpack_require__(155);
 	__webpack_require__(156);
-	__webpack_require__(157);
+	__webpack_require__(158);
 	__webpack_require__(159);
 	__webpack_require__(160);
 	__webpack_require__(161);
@@ -358,36 +359,35 @@ return /******/ (function(modules) { // webpackBootstrap
 	__webpack_require__(172);
 	__webpack_require__(173);
 	__webpack_require__(174);
-	__webpack_require__(175);
+	__webpack_require__(176);
 	__webpack_require__(177);
-	__webpack_require__(178);
+	__webpack_require__(183);
 	__webpack_require__(184);
-	__webpack_require__(185);
+	__webpack_require__(186);
 	__webpack_require__(187);
 	__webpack_require__(188);
-	__webpack_require__(189);
+	__webpack_require__(192);
 	__webpack_require__(193);
 	__webpack_require__(194);
 	__webpack_require__(195);
 	__webpack_require__(196);
-	__webpack_require__(197);
+	__webpack_require__(198);
 	__webpack_require__(199);
 	__webpack_require__(200);
 	__webpack_require__(201);
-	__webpack_require__(202);
-	__webpack_require__(205);
+	__webpack_require__(204);
+	__webpack_require__(206);
 	__webpack_require__(207);
 	__webpack_require__(208);
-	__webpack_require__(209);
-	__webpack_require__(211);
-	__webpack_require__(213);
+	__webpack_require__(210);
+	__webpack_require__(212);
+	__webpack_require__(214);
 	__webpack_require__(215);
 	__webpack_require__(216);
-	__webpack_require__(217);
+	__webpack_require__(218);
 	__webpack_require__(219);
 	__webpack_require__(220);
 	__webpack_require__(221);
-	__webpack_require__(222);
 	__webpack_require__(228);
 	__webpack_require__(231);
 	__webpack_require__(232);
@@ -395,6 +395,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	__webpack_require__(235);
 	__webpack_require__(238);
 	__webpack_require__(239);
+	__webpack_require__(241);
 	__webpack_require__(242);
 	__webpack_require__(243);
 	__webpack_require__(244);
@@ -413,13 +414,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	__webpack_require__(257);
 	__webpack_require__(258);
 	__webpack_require__(259);
-	__webpack_require__(260);
+	__webpack_require__(261);
 	__webpack_require__(262);
 	__webpack_require__(263);
 	__webpack_require__(264);
 	__webpack_require__(265);
 	__webpack_require__(266);
-	__webpack_require__(267);
+	__webpack_require__(268);
 	__webpack_require__(269);
 	__webpack_require__(270);
 	__webpack_require__(271);
@@ -427,13 +428,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	__webpack_require__(273);
 	__webpack_require__(274);
 	__webpack_require__(275);
-	__webpack_require__(276);
+	__webpack_require__(277);
 	__webpack_require__(278);
-	__webpack_require__(279);
+	__webpack_require__(280);
 	__webpack_require__(281);
 	__webpack_require__(282);
 	__webpack_require__(283);
-	__webpack_require__(284);
+	__webpack_require__(286);
 	__webpack_require__(287);
 	__webpack_require__(288);
 	__webpack_require__(289);
@@ -441,7 +442,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	__webpack_require__(291);
 	__webpack_require__(292);
 	__webpack_require__(293);
-	__webpack_require__(294);
+	__webpack_require__(295);
 	__webpack_require__(296);
 	__webpack_require__(297);
 	__webpack_require__(298);
@@ -452,9 +453,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	__webpack_require__(303);
 	__webpack_require__(304);
 	__webpack_require__(305);
-	__webpack_require__(306);
+	__webpack_require__(308);
 	__webpack_require__(309);
-	__webpack_require__(310);
 	module.exports = __webpack_require__(26);
 
 /***/ },
@@ -1325,6 +1325,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // Thrash, waste and sodomy: IE GC bug
 	  var iframe = __webpack_require__(32)('iframe')
 	    , i      = enumBugKeys.length
+	    , lt     = '<'
 	    , gt     = '>'
 	    , iframeDocument;
 	  iframe.style.display = 'none';
@@ -1334,7 +1335,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // html.removeChild(iframe);
 	  iframeDocument = iframe.contentWindow.document;
 	  iframeDocument.open();
-	  iframeDocument.write('<script>document.F=Object</script' + gt);
+	  iframeDocument.write(lt + 'script' + gt + 'document.F=Object' + lt + '/script' + gt);
 	  iframeDocument.close();
 	  createDict = iframeDocument.F;
 	  while(i--)delete createDict[PROTOTYPE][enumBugKeys[i]];
@@ -1352,6 +1353,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  } else result = createDict();
 	  return Properties === undefined ? result : dPs(result, Properties);
 	};
+
 
 /***/ },
 /* 64 */
@@ -2066,10 +2068,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	'use strict';
 	var $export      = __webpack_require__(25)
-	  , anInstance   = __webpack_require__(107)
 	  , toInteger    = __webpack_require__(55)
-	  , aNumberValue = __webpack_require__(108)
-	  , repeat       = __webpack_require__(109)
+	  , aNumberValue = __webpack_require__(107)
+	  , repeat       = __webpack_require__(108)
 	  , $toFixed     = 1..toFixed
 	  , floor        = Math.floor
 	  , data         = [0, 0, 0, 0, 0, 0]
@@ -2181,16 +2182,6 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ },
 /* 107 */
-/***/ function(module, exports) {
-
-	module.exports = function(it, Constructor, name, forbiddenField){
-	  if(!(it instanceof Constructor) || (forbiddenField !== undefined && forbiddenField in it)){
-	    throw TypeError(name + ': incorrect invocation!');
-	  } return it;
-	};
-
-/***/ },
-/* 108 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var cof = __webpack_require__(51);
@@ -2200,7 +2191,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 109 */
+/* 108 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -2217,13 +2208,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 110 */
+/* 109 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var $export      = __webpack_require__(25)
 	  , $fails       = __webpack_require__(24)
-	  , aNumberValue = __webpack_require__(108)
+	  , aNumberValue = __webpack_require__(107)
 	  , $toPrecision = 1..toPrecision;
 
 	$export($export.P + $export.F * ($fails(function(){
@@ -2240,7 +2231,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 111 */
+/* 110 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.1.2.1 Number.EPSILON
@@ -2249,7 +2240,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S, 'Number', {EPSILON: Math.pow(2, -52)});
 
 /***/ },
-/* 112 */
+/* 111 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.1.2.2 Number.isFinite(number)
@@ -2263,16 +2254,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 113 */
+/* 112 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.1.2.3 Number.isInteger(number)
 	var $export = __webpack_require__(25);
 
-	$export($export.S, 'Number', {isInteger: __webpack_require__(114)});
+	$export($export.S, 'Number', {isInteger: __webpack_require__(113)});
 
 /***/ },
-/* 114 */
+/* 113 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.1.2.3 Number.isInteger(number)
@@ -2283,7 +2274,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 115 */
+/* 114 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.1.2.4 Number.isNaN(number)
@@ -2296,12 +2287,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 116 */
+/* 115 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.1.2.5 Number.isSafeInteger(number)
 	var $export   = __webpack_require__(25)
-	  , isInteger = __webpack_require__(114)
+	  , isInteger = __webpack_require__(113)
 	  , abs       = Math.abs;
 
 	$export($export.S, 'Number', {
@@ -2311,7 +2302,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 117 */
+/* 116 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.1.2.6 Number.MAX_SAFE_INTEGER
@@ -2320,7 +2311,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S, 'Number', {MAX_SAFE_INTEGER: 0x1fffffffffffff});
 
 /***/ },
-/* 118 */
+/* 117 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.1.2.10 Number.MIN_SAFE_INTEGER
@@ -2329,7 +2320,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S, 'Number', {MIN_SAFE_INTEGER: -0x1fffffffffffff});
 
 /***/ },
-/* 119 */
+/* 118 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var $export     = __webpack_require__(25)
@@ -2338,7 +2329,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S + $export.F * (Number.parseFloat != $parseFloat), 'Number', {parseFloat: $parseFloat});
 
 /***/ },
-/* 120 */
+/* 119 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var $export   = __webpack_require__(25)
@@ -2347,12 +2338,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S + $export.F * (Number.parseInt != $parseInt), 'Number', {parseInt: $parseInt});
 
 /***/ },
-/* 121 */
+/* 120 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.3 Math.acosh(x)
 	var $export = __webpack_require__(25)
-	  , log1p   = __webpack_require__(122)
+	  , log1p   = __webpack_require__(121)
 	  , sqrt    = Math.sqrt
 	  , $acosh  = Math.acosh;
 
@@ -2370,7 +2361,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 122 */
+/* 121 */
 /***/ function(module, exports) {
 
 	// 20.2.2.20 Math.log1p(x)
@@ -2379,7 +2370,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 123 */
+/* 122 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.5 Math.asinh(x)
@@ -2394,7 +2385,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S + $export.F * !($asinh && 1 / $asinh(0) > 0), 'Math', {asinh: asinh});
 
 /***/ },
-/* 124 */
+/* 123 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.7 Math.atanh(x)
@@ -2409,12 +2400,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 125 */
+/* 124 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.9 Math.cbrt(x)
 	var $export = __webpack_require__(25)
-	  , sign    = __webpack_require__(126);
+	  , sign    = __webpack_require__(125);
 
 	$export($export.S, 'Math', {
 	  cbrt: function cbrt(x){
@@ -2423,7 +2414,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 126 */
+/* 125 */
 /***/ function(module, exports) {
 
 	// 20.2.2.28 Math.sign(x)
@@ -2432,7 +2423,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 127 */
+/* 126 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.11 Math.clz32(x)
@@ -2445,7 +2436,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 128 */
+/* 127 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.12 Math.cosh(x)
@@ -2459,17 +2450,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 129 */
+/* 128 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.14 Math.expm1(x)
 	var $export = __webpack_require__(25)
-	  , $expm1  = __webpack_require__(130);
+	  , $expm1  = __webpack_require__(129);
 
 	$export($export.S + $export.F * ($expm1 != Math.expm1), 'Math', {expm1: $expm1});
 
 /***/ },
-/* 130 */
+/* 129 */
 /***/ function(module, exports) {
 
 	// 20.2.2.14 Math.expm1(x)
@@ -2484,12 +2475,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	} : $expm1;
 
 /***/ },
-/* 131 */
+/* 130 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.16 Math.fround(x)
 	var $export   = __webpack_require__(25)
-	  , sign      = __webpack_require__(126)
+	  , sign      = __webpack_require__(125)
 	  , pow       = Math.pow
 	  , EPSILON   = pow(2, -52)
 	  , EPSILON32 = pow(2, -23)
@@ -2515,7 +2506,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 132 */
+/* 131 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.17 Math.hypot([value1[, value2[, … ]]])
@@ -2545,7 +2536,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 133 */
+/* 132 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.18 Math.imul(x, y)
@@ -2567,7 +2558,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 134 */
+/* 133 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.21 Math.log10(x)
@@ -2580,16 +2571,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 135 */
+/* 134 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.20 Math.log1p(x)
 	var $export = __webpack_require__(25);
 
-	$export($export.S, 'Math', {log1p: __webpack_require__(122)});
+	$export($export.S, 'Math', {log1p: __webpack_require__(121)});
 
 /***/ },
-/* 136 */
+/* 135 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.22 Math.log2(x)
@@ -2602,21 +2593,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 137 */
+/* 136 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.28 Math.sign(x)
 	var $export = __webpack_require__(25);
 
-	$export($export.S, 'Math', {sign: __webpack_require__(126)});
+	$export($export.S, 'Math', {sign: __webpack_require__(125)});
 
 /***/ },
-/* 138 */
+/* 137 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.30 Math.sinh(x)
 	var $export = __webpack_require__(25)
-	  , expm1   = __webpack_require__(130)
+	  , expm1   = __webpack_require__(129)
 	  , exp     = Math.exp;
 
 	// V8 near Chromium 38 has a problem with very small numbers
@@ -2631,12 +2622,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 139 */
+/* 138 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.33 Math.tanh(x)
 	var $export = __webpack_require__(25)
-	  , expm1   = __webpack_require__(130)
+	  , expm1   = __webpack_require__(129)
 	  , exp     = Math.exp;
 
 	$export($export.S, 'Math', {
@@ -2648,7 +2639,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 140 */
+/* 139 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.2.2.34 Math.trunc(x)
@@ -2661,7 +2652,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 141 */
+/* 140 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var $export        = __webpack_require__(25)
@@ -2689,7 +2680,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 142 */
+/* 141 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var $export   = __webpack_require__(25)
@@ -2712,7 +2703,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 143 */
+/* 142 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -2724,14 +2715,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 144 */
+/* 143 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	var $at  = __webpack_require__(145)(true);
+	var $at  = __webpack_require__(144)(true);
 
 	// 21.1.3.27 String.prototype[@@iterator]()
-	__webpack_require__(146)(String, 'String', function(iterated){
+	__webpack_require__(145)(String, 'String', function(iterated){
 	  this._t = String(iterated); // target
 	  this._i = 0;                // next index
 	// 21.1.5.2.1 %StringIteratorPrototype%.next()
@@ -2746,7 +2737,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 145 */
+/* 144 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var toInteger = __webpack_require__(55)
@@ -2768,7 +2759,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 146 */
+/* 145 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -2777,8 +2768,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , redefine       = __webpack_require__(35)
 	  , hide           = __webpack_require__(27)
 	  , has            = __webpack_require__(22)
-	  , Iterators      = __webpack_require__(147)
-	  , $iterCreate    = __webpack_require__(148)
+	  , Iterators      = __webpack_require__(146)
+	  , $iterCreate    = __webpack_require__(147)
 	  , setToStringTag = __webpack_require__(41)
 	  , getPrototypeOf = __webpack_require__(76)
 	  , ITERATOR       = __webpack_require__(42)('iterator')
@@ -2843,13 +2834,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 147 */
+/* 146 */
 /***/ function(module, exports) {
 
 	module.exports = {};
 
 /***/ },
-/* 148 */
+/* 147 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -2867,12 +2858,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 149 */
+/* 148 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var $export = __webpack_require__(25)
-	  , $at     = __webpack_require__(145)(false);
+	  , $at     = __webpack_require__(144)(false);
 	$export($export.P, 'String', {
 	  // 21.1.3.3 String.prototype.codePointAt(pos)
 	  codePointAt: function codePointAt(pos){
@@ -2881,18 +2872,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 150 */
+/* 149 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 21.1.3.6 String.prototype.endsWith(searchString [, endPosition])
 	'use strict';
 	var $export   = __webpack_require__(25)
 	  , toLength  = __webpack_require__(54)
-	  , context   = __webpack_require__(151)
+	  , context   = __webpack_require__(150)
 	  , ENDS_WITH = 'endsWith'
 	  , $endsWith = ''[ENDS_WITH];
 
-	$export($export.P + $export.F * __webpack_require__(153)(ENDS_WITH), 'String', {
+	$export($export.P + $export.F * __webpack_require__(152)(ENDS_WITH), 'String', {
 	  endsWith: function endsWith(searchString /*, endPosition = @length */){
 	    var that = context(this, searchString, ENDS_WITH)
 	      , endPosition = arguments.length > 1 ? arguments[1] : undefined
@@ -2906,11 +2897,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 151 */
+/* 150 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// helper for String#{startsWith, endsWith, includes}
-	var isRegExp = __webpack_require__(152)
+	var isRegExp = __webpack_require__(151)
 	  , defined  = __webpack_require__(52);
 
 	module.exports = function(that, searchString, NAME){
@@ -2919,7 +2910,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 152 */
+/* 151 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 7.2.8 IsRegExp(argument)
@@ -2932,7 +2923,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 153 */
+/* 152 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var MATCH = __webpack_require__(42)('match');
@@ -2949,16 +2940,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 154 */
+/* 153 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 21.1.3.7 String.prototype.includes(searchString, position = 0)
 	'use strict';
 	var $export  = __webpack_require__(25)
-	  , context  = __webpack_require__(151)
+	  , context  = __webpack_require__(150)
 	  , INCLUDES = 'includes';
 
-	$export($export.P + $export.F * __webpack_require__(153)(INCLUDES), 'String', {
+	$export($export.P + $export.F * __webpack_require__(152)(INCLUDES), 'String', {
 	  includes: function includes(searchString /*, position = 0 */){
 	    return !!~context(this, searchString, INCLUDES)
 	      .indexOf(searchString, arguments.length > 1 ? arguments[1] : undefined);
@@ -2966,29 +2957,29 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 155 */
+/* 154 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var $export = __webpack_require__(25);
 
 	$export($export.P, 'String', {
 	  // 21.1.3.13 String.prototype.repeat(count)
-	  repeat: __webpack_require__(109)
+	  repeat: __webpack_require__(108)
 	});
 
 /***/ },
-/* 156 */
+/* 155 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 21.1.3.18 String.prototype.startsWith(searchString [, position ])
 	'use strict';
 	var $export     = __webpack_require__(25)
 	  , toLength    = __webpack_require__(54)
-	  , context     = __webpack_require__(151)
+	  , context     = __webpack_require__(150)
 	  , STARTS_WITH = 'startsWith'
 	  , $startsWith = ''[STARTS_WITH];
 
-	$export($export.P + $export.F * __webpack_require__(153)(STARTS_WITH), 'String', {
+	$export($export.P + $export.F * __webpack_require__(152)(STARTS_WITH), 'String', {
 	  startsWith: function startsWith(searchString /*, position = 0 */){
 	    var that   = context(this, searchString, STARTS_WITH)
 	      , index  = toLength(Math.min(arguments.length > 1 ? arguments[1] : undefined, that.length))
@@ -3000,19 +2991,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 157 */
+/* 156 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	// B.2.3.2 String.prototype.anchor(name)
-	__webpack_require__(158)('anchor', function(createHTML){
+	__webpack_require__(157)('anchor', function(createHTML){
 	  return function anchor(name){
 	    return createHTML(this, 'a', 'name', name);
 	  }
 	});
 
 /***/ },
-/* 158 */
+/* 157 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var $export = __webpack_require__(25)
@@ -3036,14 +3027,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 159 */
+/* 158 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	// B.2.3.3 String.prototype.big()
-	__webpack_require__(158)('big', function(createHTML){
+	__webpack_require__(157)('big', function(createHTML){
 	  return function big(){
 	    return createHTML(this, 'big', '', '');
+	  }
+	});
+
+/***/ },
+/* 159 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+	// B.2.3.4 String.prototype.blink()
+	__webpack_require__(157)('blink', function(createHTML){
+	  return function blink(){
+	    return createHTML(this, 'blink', '', '');
 	  }
 	});
 
@@ -3052,10 +3055,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.4 String.prototype.blink()
-	__webpack_require__(158)('blink', function(createHTML){
-	  return function blink(){
-	    return createHTML(this, 'blink', '', '');
+	// B.2.3.5 String.prototype.bold()
+	__webpack_require__(157)('bold', function(createHTML){
+	  return function bold(){
+	    return createHTML(this, 'b', '', '');
 	  }
 	});
 
@@ -3064,10 +3067,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.5 String.prototype.bold()
-	__webpack_require__(158)('bold', function(createHTML){
-	  return function bold(){
-	    return createHTML(this, 'b', '', '');
+	// B.2.3.6 String.prototype.fixed()
+	__webpack_require__(157)('fixed', function(createHTML){
+	  return function fixed(){
+	    return createHTML(this, 'tt', '', '');
 	  }
 	});
 
@@ -3076,10 +3079,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.6 String.prototype.fixed()
-	__webpack_require__(158)('fixed', function(createHTML){
-	  return function fixed(){
-	    return createHTML(this, 'tt', '', '');
+	// B.2.3.7 String.prototype.fontcolor(color)
+	__webpack_require__(157)('fontcolor', function(createHTML){
+	  return function fontcolor(color){
+	    return createHTML(this, 'font', 'color', color);
 	  }
 	});
 
@@ -3088,10 +3091,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.7 String.prototype.fontcolor(color)
-	__webpack_require__(158)('fontcolor', function(createHTML){
-	  return function fontcolor(color){
-	    return createHTML(this, 'font', 'color', color);
+	// B.2.3.8 String.prototype.fontsize(size)
+	__webpack_require__(157)('fontsize', function(createHTML){
+	  return function fontsize(size){
+	    return createHTML(this, 'font', 'size', size);
 	  }
 	});
 
@@ -3100,10 +3103,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.8 String.prototype.fontsize(size)
-	__webpack_require__(158)('fontsize', function(createHTML){
-	  return function fontsize(size){
-	    return createHTML(this, 'font', 'size', size);
+	// B.2.3.9 String.prototype.italics()
+	__webpack_require__(157)('italics', function(createHTML){
+	  return function italics(){
+	    return createHTML(this, 'i', '', '');
 	  }
 	});
 
@@ -3112,10 +3115,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.9 String.prototype.italics()
-	__webpack_require__(158)('italics', function(createHTML){
-	  return function italics(){
-	    return createHTML(this, 'i', '', '');
+	// B.2.3.10 String.prototype.link(url)
+	__webpack_require__(157)('link', function(createHTML){
+	  return function link(url){
+	    return createHTML(this, 'a', 'href', url);
 	  }
 	});
 
@@ -3124,10 +3127,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.10 String.prototype.link(url)
-	__webpack_require__(158)('link', function(createHTML){
-	  return function link(url){
-	    return createHTML(this, 'a', 'href', url);
+	// B.2.3.11 String.prototype.small()
+	__webpack_require__(157)('small', function(createHTML){
+	  return function small(){
+	    return createHTML(this, 'small', '', '');
 	  }
 	});
 
@@ -3136,10 +3139,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.11 String.prototype.small()
-	__webpack_require__(158)('small', function(createHTML){
-	  return function small(){
-	    return createHTML(this, 'small', '', '');
+	// B.2.3.12 String.prototype.strike()
+	__webpack_require__(157)('strike', function(createHTML){
+	  return function strike(){
+	    return createHTML(this, 'strike', '', '');
 	  }
 	});
 
@@ -3148,10 +3151,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.12 String.prototype.strike()
-	__webpack_require__(158)('strike', function(createHTML){
-	  return function strike(){
-	    return createHTML(this, 'strike', '', '');
+	// B.2.3.13 String.prototype.sub()
+	__webpack_require__(157)('sub', function(createHTML){
+	  return function sub(){
+	    return createHTML(this, 'sub', '', '');
 	  }
 	});
 
@@ -3160,27 +3163,15 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	// B.2.3.13 String.prototype.sub()
-	__webpack_require__(158)('sub', function(createHTML){
-	  return function sub(){
-	    return createHTML(this, 'sub', '', '');
-	  }
-	});
-
-/***/ },
-/* 170 */
-/***/ function(module, exports, __webpack_require__) {
-
-	'use strict';
 	// B.2.3.14 String.prototype.sup()
-	__webpack_require__(158)('sup', function(createHTML){
+	__webpack_require__(157)('sup', function(createHTML){
 	  return function sup(){
 	    return createHTML(this, 'sup', '', '');
 	  }
 	});
 
 /***/ },
-/* 171 */
+/* 170 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 20.3.3.1 / 15.9.4.4 Date.now()
@@ -3189,7 +3180,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S, 'Date', {now: function(){ return new Date().getTime(); }});
 
 /***/ },
-/* 172 */
+/* 171 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3208,7 +3199,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 173 */
+/* 172 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3241,7 +3232,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 174 */
+/* 173 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var DateProto    = Date.prototype
@@ -3257,16 +3248,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 175 */
+/* 174 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var TO_PRIMITIVE = __webpack_require__(42)('toPrimitive')
 	  , proto        = Date.prototype;
 
-	if(!(TO_PRIMITIVE in proto))__webpack_require__(27)(proto, TO_PRIMITIVE, __webpack_require__(176));
+	if(!(TO_PRIMITIVE in proto))__webpack_require__(27)(proto, TO_PRIMITIVE, __webpack_require__(175));
 
 /***/ },
-/* 176 */
+/* 175 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3280,7 +3271,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 177 */
+/* 176 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 22.1.2.2 / 15.4.3.2 Array.isArray(arg)
@@ -3289,20 +3280,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S, 'Array', {isArray: __webpack_require__(62)});
 
 /***/ },
-/* 178 */
+/* 177 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var ctx            = __webpack_require__(37)
 	  , $export        = __webpack_require__(25)
 	  , toObject       = __webpack_require__(75)
-	  , call           = __webpack_require__(179)
-	  , isArrayIter    = __webpack_require__(180)
+	  , call           = __webpack_require__(178)
+	  , isArrayIter    = __webpack_require__(179)
 	  , toLength       = __webpack_require__(54)
-	  , createProperty = __webpack_require__(181)
-	  , getIterFn      = __webpack_require__(182);
+	  , createProperty = __webpack_require__(180)
+	  , getIterFn      = __webpack_require__(181);
 
-	$export($export.S + $export.F * !__webpack_require__(183)(function(iter){ Array.from(iter); }), 'Array', {
+	$export($export.S + $export.F * !__webpack_require__(182)(function(iter){ Array.from(iter); }), 'Array', {
 	  // 22.1.2.1 Array.from(arrayLike, mapfn = undefined, thisArg = undefined)
 	  from: function from(arrayLike/*, mapfn = undefined, thisArg = undefined*/){
 	    var O       = toObject(arrayLike)
@@ -3332,7 +3323,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 179 */
+/* 178 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// call something on iterator step with safe closing on error
@@ -3349,11 +3340,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 180 */
+/* 179 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// check on default Array iterator
-	var Iterators  = __webpack_require__(147)
+	var Iterators  = __webpack_require__(146)
 	  , ITERATOR   = __webpack_require__(42)('iterator')
 	  , ArrayProto = Array.prototype;
 
@@ -3362,7 +3353,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 181 */
+/* 180 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3375,12 +3366,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 182 */
+/* 181 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var classof   = __webpack_require__(92)
 	  , ITERATOR  = __webpack_require__(42)('iterator')
-	  , Iterators = __webpack_require__(147);
+	  , Iterators = __webpack_require__(146);
 	module.exports = __webpack_require__(26).getIteratorMethod = function(it){
 	  if(it != undefined)return it[ITERATOR]
 	    || it['@@iterator']
@@ -3388,7 +3379,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 183 */
+/* 182 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var ITERATOR     = __webpack_require__(42)('iterator')
@@ -3414,12 +3405,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 184 */
+/* 183 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var $export        = __webpack_require__(25)
-	  , createProperty = __webpack_require__(181);
+	  , createProperty = __webpack_require__(180);
 
 	// WebKit Array.of isn't generic
 	$export($export.S + $export.F * __webpack_require__(24)(function(){
@@ -3438,7 +3429,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 185 */
+/* 184 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3448,14 +3439,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , arrayJoin = [].join;
 
 	// fallback for not array-like strings
-	$export($export.P + $export.F * (__webpack_require__(50) != Object || !__webpack_require__(186)(arrayJoin)), 'Array', {
+	$export($export.P + $export.F * (__webpack_require__(50) != Object || !__webpack_require__(185)(arrayJoin)), 'Array', {
 	  join: function join(separator){
 	    return arrayJoin.call(toIObject(this), separator === undefined ? ',' : separator);
 	  }
 	});
 
 /***/ },
-/* 186 */
+/* 185 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var fails = __webpack_require__(24);
@@ -3467,7 +3458,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 187 */
+/* 186 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3500,7 +3491,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 188 */
+/* 187 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3518,7 +3509,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // V8 bug
 	  test.sort(null);
 	  // Old WebKit
-	}) || !__webpack_require__(186)($sort)), 'Array', {
+	}) || !__webpack_require__(185)($sort)), 'Array', {
 	  // 22.1.3.25 Array.prototype.sort(comparefn)
 	  sort: function sort(comparefn){
 	    return comparefn === undefined
@@ -3528,13 +3519,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 189 */
+/* 188 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var $export  = __webpack_require__(25)
-	  , $forEach = __webpack_require__(190)(0)
-	  , STRICT   = __webpack_require__(186)([].forEach, true);
+	  , $forEach = __webpack_require__(189)(0)
+	  , STRICT   = __webpack_require__(185)([].forEach, true);
 
 	$export($export.P + $export.F * !STRICT, 'Array', {
 	  // 22.1.3.10 / 15.4.4.18 Array.prototype.forEach(callbackfn [, thisArg])
@@ -3544,7 +3535,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 190 */
+/* 189 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 0 -> Array#forEach
@@ -3558,7 +3549,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , IObject  = __webpack_require__(50)
 	  , toObject = __webpack_require__(75)
 	  , toLength = __webpack_require__(54)
-	  , asc      = __webpack_require__(191);
+	  , asc      = __webpack_require__(190);
 	module.exports = function(TYPE, $create){
 	  var IS_MAP        = TYPE == 1
 	    , IS_FILTER     = TYPE == 2
@@ -3593,18 +3584,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 191 */
+/* 190 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 9.4.2.3 ArraySpeciesCreate(originalArray, length)
-	var speciesConstructor = __webpack_require__(192);
+	var speciesConstructor = __webpack_require__(191);
 
 	module.exports = function(original, length){
 	  return new (speciesConstructor(original))(length);
 	};
 
 /***/ },
-/* 192 */
+/* 191 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var isObject = __webpack_require__(30)
@@ -3625,17 +3616,32 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
+/* 192 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var $export = __webpack_require__(25)
+	  , $map    = __webpack_require__(189)(1);
+
+	$export($export.P + $export.F * !__webpack_require__(185)([].map, true), 'Array', {
+	  // 22.1.3.15 / 15.4.4.19 Array.prototype.map(callbackfn [, thisArg])
+	  map: function map(callbackfn /* , thisArg */){
+	    return $map(this, callbackfn, arguments[1]);
+	  }
+	});
+
+/***/ },
 /* 193 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var $export = __webpack_require__(25)
-	  , $map    = __webpack_require__(190)(1);
+	  , $filter = __webpack_require__(189)(2);
 
-	$export($export.P + $export.F * !__webpack_require__(186)([].map, true), 'Array', {
-	  // 22.1.3.15 / 15.4.4.19 Array.prototype.map(callbackfn [, thisArg])
-	  map: function map(callbackfn /* , thisArg */){
-	    return $map(this, callbackfn, arguments[1]);
+	$export($export.P + $export.F * !__webpack_require__(185)([].filter, true), 'Array', {
+	  // 22.1.3.7 / 15.4.4.20 Array.prototype.filter(callbackfn [, thisArg])
+	  filter: function filter(callbackfn /* , thisArg */){
+	    return $filter(this, callbackfn, arguments[1]);
 	  }
 	});
 
@@ -3645,12 +3651,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	'use strict';
 	var $export = __webpack_require__(25)
-	  , $filter = __webpack_require__(190)(2);
+	  , $some   = __webpack_require__(189)(3);
 
-	$export($export.P + $export.F * !__webpack_require__(186)([].filter, true), 'Array', {
-	  // 22.1.3.7 / 15.4.4.20 Array.prototype.filter(callbackfn [, thisArg])
-	  filter: function filter(callbackfn /* , thisArg */){
-	    return $filter(this, callbackfn, arguments[1]);
+	$export($export.P + $export.F * !__webpack_require__(185)([].some, true), 'Array', {
+	  // 22.1.3.23 / 15.4.4.17 Array.prototype.some(callbackfn [, thisArg])
+	  some: function some(callbackfn /* , thisArg */){
+	    return $some(this, callbackfn, arguments[1]);
 	  }
 	});
 
@@ -3660,12 +3666,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	'use strict';
 	var $export = __webpack_require__(25)
-	  , $some   = __webpack_require__(190)(3);
+	  , $every  = __webpack_require__(189)(4);
 
-	$export($export.P + $export.F * !__webpack_require__(186)([].some, true), 'Array', {
-	  // 22.1.3.23 / 15.4.4.17 Array.prototype.some(callbackfn [, thisArg])
-	  some: function some(callbackfn /* , thisArg */){
-	    return $some(this, callbackfn, arguments[1]);
+	$export($export.P + $export.F * !__webpack_require__(185)([].every, true), 'Array', {
+	  // 22.1.3.5 / 15.4.4.16 Array.prototype.every(callbackfn [, thisArg])
+	  every: function every(callbackfn /* , thisArg */){
+	    return $every(this, callbackfn, arguments[1]);
 	  }
 	});
 
@@ -3675,24 +3681,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	'use strict';
 	var $export = __webpack_require__(25)
-	  , $every  = __webpack_require__(190)(4);
+	  , $reduce = __webpack_require__(197);
 
-	$export($export.P + $export.F * !__webpack_require__(186)([].every, true), 'Array', {
-	  // 22.1.3.5 / 15.4.4.16 Array.prototype.every(callbackfn [, thisArg])
-	  every: function every(callbackfn /* , thisArg */){
-	    return $every(this, callbackfn, arguments[1]);
-	  }
-	});
-
-/***/ },
-/* 197 */
-/***/ function(module, exports, __webpack_require__) {
-
-	'use strict';
-	var $export = __webpack_require__(25)
-	  , $reduce = __webpack_require__(198);
-
-	$export($export.P + $export.F * !__webpack_require__(186)([].reduce, true), 'Array', {
+	$export($export.P + $export.F * !__webpack_require__(185)([].reduce, true), 'Array', {
 	  // 22.1.3.18 / 15.4.4.21 Array.prototype.reduce(callbackfn [, initialValue])
 	  reduce: function reduce(callbackfn /* , initialValue */){
 	    return $reduce(this, callbackfn, arguments.length, arguments[1], false);
@@ -3700,7 +3691,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 198 */
+/* 197 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var aFunction = __webpack_require__(38)
@@ -3733,14 +3724,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 199 */
+/* 198 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	var $export = __webpack_require__(25)
-	  , $reduce = __webpack_require__(198);
+	  , $reduce = __webpack_require__(197);
 
-	$export($export.P + $export.F * !__webpack_require__(186)([].reduceRight, true), 'Array', {
+	$export($export.P + $export.F * !__webpack_require__(185)([].reduceRight, true), 'Array', {
 	  // 22.1.3.19 / 15.4.4.22 Array.prototype.reduceRight(callbackfn [, initialValue])
 	  reduceRight: function reduceRight(callbackfn /* , initialValue */){
 	    return $reduce(this, callbackfn, arguments.length, arguments[1], true);
@@ -3748,7 +3739,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 200 */
+/* 199 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3757,7 +3748,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , $native       = [].indexOf
 	  , NEGATIVE_ZERO = !!$native && 1 / [1].indexOf(1, -0) < 0;
 
-	$export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(186)($native)), 'Array', {
+	$export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(185)($native)), 'Array', {
 	  // 22.1.3.11 / 15.4.4.14 Array.prototype.indexOf(searchElement [, fromIndex])
 	  indexOf: function indexOf(searchElement /*, fromIndex = 0 */){
 	    return NEGATIVE_ZERO
@@ -3768,7 +3759,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 201 */
+/* 200 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3779,7 +3770,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , $native       = [].lastIndexOf
 	  , NEGATIVE_ZERO = !!$native && 1 / [1].lastIndexOf(1, -0) < 0;
 
-	$export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(186)($native)), 'Array', {
+	$export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(185)($native)), 'Array', {
 	  // 22.1.3.14 / 15.4.4.15 Array.prototype.lastIndexOf(searchElement [, fromIndex])
 	  lastIndexOf: function lastIndexOf(searchElement /*, fromIndex = @[*-1] */){
 	    // convert -0 to +0
@@ -3795,18 +3786,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 202 */
+/* 201 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 22.1.3.3 Array.prototype.copyWithin(target, start, end = this.length)
 	var $export = __webpack_require__(25);
 
-	$export($export.P, 'Array', {copyWithin: __webpack_require__(203)});
+	$export($export.P, 'Array', {copyWithin: __webpack_require__(202)});
 
-	__webpack_require__(204)('copyWithin');
+	__webpack_require__(203)('copyWithin');
 
 /***/ },
-/* 203 */
+/* 202 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 22.1.3.3 Array.prototype.copyWithin(target, start, end = this.length)
@@ -3837,7 +3828,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 204 */
+/* 203 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 22.1.3.31 Array.prototype[@@unscopables]
@@ -3849,18 +3840,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 205 */
+/* 204 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 22.1.3.6 Array.prototype.fill(value, start = 0, end = this.length)
 	var $export = __webpack_require__(25);
 
-	$export($export.P, 'Array', {fill: __webpack_require__(206)});
+	$export($export.P, 'Array', {fill: __webpack_require__(205)});
 
-	__webpack_require__(204)('fill');
+	__webpack_require__(203)('fill');
 
 /***/ },
-/* 206 */
+/* 205 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 22.1.3.6 Array.prototype.fill(value, start = 0, end = this.length)
@@ -3880,13 +3871,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 207 */
+/* 206 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	// 22.1.3.8 Array.prototype.find(predicate, thisArg = undefined)
 	var $export = __webpack_require__(25)
-	  , $find   = __webpack_require__(190)(5)
+	  , $find   = __webpack_require__(189)(5)
 	  , KEY     = 'find'
 	  , forced  = true;
 	// Shouldn't skip holes
@@ -3896,16 +3887,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return $find(this, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
 	  }
 	});
-	__webpack_require__(204)(KEY);
+	__webpack_require__(203)(KEY);
 
 /***/ },
-/* 208 */
+/* 207 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	// 22.1.3.9 Array.prototype.findIndex(predicate, thisArg = undefined)
 	var $export = __webpack_require__(25)
-	  , $find   = __webpack_require__(190)(6)
+	  , $find   = __webpack_require__(189)(6)
 	  , KEY     = 'findIndex'
 	  , forced  = true;
 	// Shouldn't skip holes
@@ -3915,16 +3906,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return $find(this, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
 	  }
 	});
-	__webpack_require__(204)(KEY);
+	__webpack_require__(203)(KEY);
+
+/***/ },
+/* 208 */
+/***/ function(module, exports, __webpack_require__) {
+
+	__webpack_require__(209)('Array');
 
 /***/ },
 /* 209 */
-/***/ function(module, exports, __webpack_require__) {
-
-	__webpack_require__(210)('Array');
-
-/***/ },
-/* 210 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -3942,20 +3933,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 211 */
+/* 210 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	var addToUnscopables = __webpack_require__(204)
-	  , step             = __webpack_require__(212)
-	  , Iterators        = __webpack_require__(147)
+	var addToUnscopables = __webpack_require__(203)
+	  , step             = __webpack_require__(211)
+	  , Iterators        = __webpack_require__(146)
 	  , toIObject        = __webpack_require__(49);
 
 	// 22.1.3.4 Array.prototype.entries()
 	// 22.1.3.13 Array.prototype.keys()
 	// 22.1.3.29 Array.prototype.values()
 	// 22.1.3.30 Array.prototype[@@iterator]()
-	module.exports = __webpack_require__(146)(Array, 'Array', function(iterated, kind){
+	module.exports = __webpack_require__(145)(Array, 'Array', function(iterated, kind){
 	  this._t = toIObject(iterated); // target
 	  this._i = 0;                   // next index
 	  this._k = kind;                // kind
@@ -3981,7 +3972,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	addToUnscopables('entries');
 
 /***/ },
-/* 212 */
+/* 211 */
 /***/ function(module, exports) {
 
 	module.exports = function(done, value){
@@ -3989,15 +3980,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 213 */
+/* 212 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var global            = __webpack_require__(21)
 	  , inheritIfRequired = __webpack_require__(105)
 	  , dP                = __webpack_require__(28).f
 	  , gOPN              = __webpack_require__(67).f
-	  , isRegExp          = __webpack_require__(152)
-	  , $flags            = __webpack_require__(214)
+	  , isRegExp          = __webpack_require__(151)
+	  , $flags            = __webpack_require__(213)
 	  , $RegExp           = global.RegExp
 	  , Base              = $RegExp
 	  , proto             = $RegExp.prototype
@@ -4034,10 +4025,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  __webpack_require__(35)(global, 'RegExp', $RegExp);
 	}
 
-	__webpack_require__(210)('RegExp');
+	__webpack_require__(209)('RegExp');
 
 /***/ },
-/* 214 */
+/* 213 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -4055,13 +4046,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 215 */
+/* 214 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	__webpack_require__(216);
+	__webpack_require__(215);
 	var anObject    = __webpack_require__(29)
-	  , $flags      = __webpack_require__(214)
+	  , $flags      = __webpack_require__(213)
 	  , DESCRIPTORS = __webpack_require__(23)
 	  , TO_STRING   = 'toString'
 	  , $toString   = /./[TO_STRING];
@@ -4085,21 +4076,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 216 */
+/* 215 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 21.2.5.3 get RegExp.prototype.flags()
 	if(__webpack_require__(23) && /./g.flags != 'g')__webpack_require__(28).f(RegExp.prototype, 'flags', {
 	  configurable: true,
-	  get: __webpack_require__(214)
+	  get: __webpack_require__(213)
 	});
 
 /***/ },
-/* 217 */
+/* 216 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// @@match logic
-	__webpack_require__(218)('match', 1, function(defined, MATCH, $match){
+	__webpack_require__(217)('match', 1, function(defined, MATCH, $match){
 	  // 21.1.3.11 String.prototype.match(regexp)
 	  return [function match(regexp){
 	    'use strict';
@@ -4110,7 +4101,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 218 */
+/* 217 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -4143,11 +4134,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 219 */
+/* 218 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// @@replace logic
-	__webpack_require__(218)('replace', 2, function(defined, REPLACE, $replace){
+	__webpack_require__(217)('replace', 2, function(defined, REPLACE, $replace){
 	  // 21.1.3.14 String.prototype.replace(searchValue, replaceValue)
 	  return [function replace(searchValue, replaceValue){
 	    'use strict';
@@ -4160,11 +4151,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 220 */
+/* 219 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// @@search logic
-	__webpack_require__(218)('search', 1, function(defined, SEARCH, $search){
+	__webpack_require__(217)('search', 1, function(defined, SEARCH, $search){
 	  // 21.1.3.15 String.prototype.search(regexp)
 	  return [function search(regexp){
 	    'use strict';
@@ -4175,13 +4166,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 221 */
+/* 220 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// @@split logic
-	__webpack_require__(218)('split', 2, function(defined, SPLIT, $split){
+	__webpack_require__(217)('split', 2, function(defined, SPLIT, $split){
 	  'use strict';
-	  var isRegExp   = __webpack_require__(152)
+	  var isRegExp   = __webpack_require__(151)
 	    , _split     = $split
 	    , $push      = [].push
 	    , $SPLIT     = 'split'
@@ -4250,7 +4241,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 222 */
+/* 221 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -4260,11 +4251,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , classof            = __webpack_require__(92)
 	  , $export            = __webpack_require__(25)
 	  , isObject           = __webpack_require__(30)
-	  , anObject           = __webpack_require__(29)
 	  , aFunction          = __webpack_require__(38)
-	  , anInstance         = __webpack_require__(107)
+	  , anInstance         = __webpack_require__(222)
 	  , forOf              = __webpack_require__(223)
-	  , setProto           = __webpack_require__(90).set
 	  , speciesConstructor = __webpack_require__(224)
 	  , task               = __webpack_require__(225).set
 	  , microtask          = __webpack_require__(226)()
@@ -4486,7 +4475,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	$export($export.G + $export.W + $export.F * !USE_NATIVE, {Promise: $Promise});
 	__webpack_require__(41)($Promise, PROMISE);
-	__webpack_require__(210)(PROMISE);
+	__webpack_require__(209)(PROMISE);
 	Wrapper = __webpack_require__(26)[PROMISE];
 
 	// statics
@@ -4510,7 +4499,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return capability.promise;
 	  }
 	});
-	$export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(183)(function(iter){
+	$export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(182)(function(iter){
 	  $Promise.all(iter)['catch'](empty);
 	})), PROMISE, {
 	  // 25.4.4.1 Promise.all(iterable)
@@ -4556,15 +4545,25 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
+/* 222 */
+/***/ function(module, exports) {
+
+	module.exports = function(it, Constructor, name, forbiddenField){
+	  if(!(it instanceof Constructor) || (forbiddenField !== undefined && forbiddenField in it)){
+	    throw TypeError(name + ': incorrect invocation!');
+	  } return it;
+	};
+
+/***/ },
 /* 223 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var ctx         = __webpack_require__(37)
-	  , call        = __webpack_require__(179)
-	  , isArrayIter = __webpack_require__(180)
+	  , call        = __webpack_require__(178)
+	  , isArrayIter = __webpack_require__(179)
 	  , anObject    = __webpack_require__(29)
 	  , toLength    = __webpack_require__(54)
-	  , getIterFn   = __webpack_require__(182)
+	  , getIterFn   = __webpack_require__(181)
 	  , BREAK       = {}
 	  , RETURN      = {};
 	var exports = module.exports = function(iterable, entries, fn, that, ITERATOR){
@@ -4790,15 +4789,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 	var dP          = __webpack_require__(28).f
 	  , create      = __webpack_require__(63)
-	  , hide        = __webpack_require__(27)
 	  , redefineAll = __webpack_require__(227)
 	  , ctx         = __webpack_require__(37)
-	  , anInstance  = __webpack_require__(107)
+	  , anInstance  = __webpack_require__(222)
 	  , defined     = __webpack_require__(52)
 	  , forOf       = __webpack_require__(223)
-	  , $iterDefine = __webpack_require__(146)
-	  , step        = __webpack_require__(212)
-	  , setSpecies  = __webpack_require__(210)
+	  , $iterDefine = __webpack_require__(145)
+	  , step        = __webpack_require__(211)
+	  , setSpecies  = __webpack_require__(209)
 	  , DESCRIPTORS = __webpack_require__(23)
 	  , fastKey     = __webpack_require__(39).fastKey
 	  , SIZE        = DESCRIPTORS ? '_s' : 'size';
@@ -4942,10 +4940,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , redefineAll       = __webpack_require__(227)
 	  , meta              = __webpack_require__(39)
 	  , forOf             = __webpack_require__(223)
-	  , anInstance        = __webpack_require__(107)
+	  , anInstance        = __webpack_require__(222)
 	  , isObject          = __webpack_require__(30)
 	  , fails             = __webpack_require__(24)
-	  , $iterDetect       = __webpack_require__(183)
+	  , $iterDetect       = __webpack_require__(182)
 	  , setToStringTag    = __webpack_require__(41)
 	  , inheritIfRequired = __webpack_require__(105);
 
@@ -5043,13 +5041,12 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	var each         = __webpack_require__(190)(0)
+	var each         = __webpack_require__(189)(0)
 	  , redefine     = __webpack_require__(35)
 	  , meta         = __webpack_require__(39)
 	  , assign       = __webpack_require__(86)
 	  , weak         = __webpack_require__(233)
 	  , isObject     = __webpack_require__(30)
-	  , has          = __webpack_require__(22)
 	  , getWeak      = meta.getWeak
 	  , isExtensible = Object.isExtensible
 	  , uncaughtFrozenStore = weak.ufstore
@@ -5109,9 +5106,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , getWeak           = __webpack_require__(39).getWeak
 	  , anObject          = __webpack_require__(29)
 	  , isObject          = __webpack_require__(30)
-	  , anInstance        = __webpack_require__(107)
+	  , anInstance        = __webpack_require__(222)
 	  , forOf             = __webpack_require__(223)
-	  , createArrayMethod = __webpack_require__(190)
+	  , createArrayMethod = __webpack_require__(189)
 	  , $has              = __webpack_require__(22)
 	  , arrayFind         = createArrayMethod(5)
 	  , arrayFindIndex    = createArrayMethod(6)
@@ -5217,7 +5214,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , toIndex      = __webpack_require__(56)
 	  , toLength     = __webpack_require__(54)
 	  , isObject     = __webpack_require__(30)
-	  , TYPED_ARRAY  = __webpack_require__(42)('typed_array')
 	  , ArrayBuffer  = __webpack_require__(21).ArrayBuffer
 	  , speciesConstructor = __webpack_require__(224)
 	  , $ArrayBuffer = buffer.ArrayBuffer
@@ -5255,7 +5251,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	});
 
-	__webpack_require__(210)(ARRAY_BUFFER);
+	__webpack_require__(209)(ARRAY_BUFFER);
 
 /***/ },
 /* 236 */
@@ -5300,12 +5296,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , hide           = __webpack_require__(27)
 	  , redefineAll    = __webpack_require__(227)
 	  , fails          = __webpack_require__(24)
-	  , anInstance     = __webpack_require__(107)
+	  , anInstance     = __webpack_require__(222)
 	  , toInteger      = __webpack_require__(55)
 	  , toLength       = __webpack_require__(54)
 	  , gOPN           = __webpack_require__(67).f
 	  , dP             = __webpack_require__(28).f
-	  , arrayFill      = __webpack_require__(206)
+	  , arrayFill      = __webpack_require__(205)
 	  , setToStringTag = __webpack_require__(41)
 	  , ARRAY_BUFFER   = 'ArrayBuffer'
 	  , DATA_VIEW      = 'DataView'
@@ -5315,13 +5311,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , $ArrayBuffer   = global[ARRAY_BUFFER]
 	  , $DataView      = global[DATA_VIEW]
 	  , Math           = global.Math
-	  , parseInt       = global.parseInt
 	  , RangeError     = global.RangeError
 	  , Infinity       = global.Infinity
 	  , BaseBuffer     = $ArrayBuffer
 	  , abs            = Math.abs
 	  , pow            = Math.pow
-	  , min            = Math.min
 	  , floor          = Math.floor
 	  , log            = Math.log
 	  , LN2            = Math.LN2
@@ -5600,11 +5594,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    , $typed              = __webpack_require__(236)
 	    , $buffer             = __webpack_require__(237)
 	    , ctx                 = __webpack_require__(37)
-	    , anInstance          = __webpack_require__(107)
+	    , anInstance          = __webpack_require__(222)
 	    , propertyDesc        = __webpack_require__(34)
 	    , hide                = __webpack_require__(27)
 	    , redefineAll         = __webpack_require__(227)
-	    , isInteger           = __webpack_require__(114)
 	    , toInteger           = __webpack_require__(55)
 	    , toLength            = __webpack_require__(54)
 	    , toIndex             = __webpack_require__(56)
@@ -5614,23 +5607,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	    , classof             = __webpack_require__(92)
 	    , isObject            = __webpack_require__(30)
 	    , toObject            = __webpack_require__(75)
-	    , isArrayIter         = __webpack_require__(180)
+	    , isArrayIter         = __webpack_require__(179)
 	    , create              = __webpack_require__(63)
 	    , getPrototypeOf      = __webpack_require__(76)
 	    , gOPN                = __webpack_require__(67).f
-	    , isIterable          = __webpack_require__(241)
-	    , getIterFn           = __webpack_require__(182)
+	    , getIterFn           = __webpack_require__(181)
 	    , uid                 = __webpack_require__(36)
 	    , wks                 = __webpack_require__(42)
-	    , createArrayMethod   = __webpack_require__(190)
+	    , createArrayMethod   = __webpack_require__(189)
 	    , createArrayIncludes = __webpack_require__(53)
 	    , speciesConstructor  = __webpack_require__(224)
-	    , ArrayIterators      = __webpack_require__(211)
-	    , Iterators           = __webpack_require__(147)
-	    , $iterDetect         = __webpack_require__(183)
-	    , setSpecies          = __webpack_require__(210)
-	    , arrayFill           = __webpack_require__(206)
-	    , arrayCopyWithin     = __webpack_require__(203)
+	    , ArrayIterators      = __webpack_require__(210)
+	    , Iterators           = __webpack_require__(146)
+	    , $iterDetect         = __webpack_require__(182)
+	    , setSpecies          = __webpack_require__(209)
+	    , arrayFill           = __webpack_require__(205)
+	    , arrayCopyWithin     = __webpack_require__(202)
 	    , $DP                 = __webpack_require__(28)
 	    , $GOPD               = __webpack_require__(68)
 	    , dP                  = $DP.f
@@ -6077,20 +6069,6 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 241 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var classof   = __webpack_require__(92)
-	  , ITERATOR  = __webpack_require__(42)('iterator')
-	  , Iterators = __webpack_require__(147);
-	module.exports = __webpack_require__(26).isIterable = function(it){
-	  var O = Object(it);
-	  return O[ITERATOR] !== undefined
-	    || '@@iterator' in O
-	    || Iterators.hasOwnProperty(classof(O));
-	};
-
-/***/ },
-/* 242 */
-/***/ function(module, exports, __webpack_require__) {
-
 	__webpack_require__(240)('Uint8', 1, function(init){
 	  return function Uint8Array(data, byteOffset, length){
 	    return init(this, data, byteOffset, length);
@@ -6098,7 +6076,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 243 */
+/* 242 */
 /***/ function(module, exports, __webpack_require__) {
 
 	__webpack_require__(240)('Uint8', 1, function(init){
@@ -6108,7 +6086,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}, true);
 
 /***/ },
-/* 244 */
+/* 243 */
 /***/ function(module, exports, __webpack_require__) {
 
 	__webpack_require__(240)('Int16', 2, function(init){
@@ -6118,7 +6096,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 245 */
+/* 244 */
 /***/ function(module, exports, __webpack_require__) {
 
 	__webpack_require__(240)('Uint16', 2, function(init){
@@ -6128,7 +6106,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 246 */
+/* 245 */
 /***/ function(module, exports, __webpack_require__) {
 
 	__webpack_require__(240)('Int32', 4, function(init){
@@ -6138,7 +6116,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 247 */
+/* 246 */
 /***/ function(module, exports, __webpack_require__) {
 
 	__webpack_require__(240)('Uint32', 4, function(init){
@@ -6148,7 +6126,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 248 */
+/* 247 */
 /***/ function(module, exports, __webpack_require__) {
 
 	__webpack_require__(240)('Float32', 4, function(init){
@@ -6158,7 +6136,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 249 */
+/* 248 */
 /***/ function(module, exports, __webpack_require__) {
 
 	__webpack_require__(240)('Float64', 8, function(init){
@@ -6168,43 +6146,56 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 250 */
+/* 249 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.1 Reflect.apply(target, thisArgument, argumentsList)
 	var $export   = __webpack_require__(25)
 	  , aFunction = __webpack_require__(38)
 	  , anObject  = __webpack_require__(29)
-	  , _apply    = Function.apply;
-
-	$export($export.S, 'Reflect', {
+	  , rApply    = (__webpack_require__(21).Reflect || {}).apply
+	  , fApply    = Function.apply;
+	// MS Edge argumentsList argument is optional
+	$export($export.S + $export.F * !__webpack_require__(24)(function(){
+	  rApply(function(){});
+	}), 'Reflect', {
 	  apply: function apply(target, thisArgument, argumentsList){
-	    return _apply.call(aFunction(target), thisArgument, anObject(argumentsList));
+	    var T = aFunction(target)
+	      , L = anObject(argumentsList);
+	    return rApply ? rApply(T, thisArgument, L) : fApply.call(T, thisArgument, L);
 	  }
 	});
 
 /***/ },
-/* 251 */
+/* 250 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.2 Reflect.construct(target, argumentsList [, newTarget])
-	var $export   = __webpack_require__(25)
-	  , create    = __webpack_require__(63)
-	  , aFunction = __webpack_require__(38)
-	  , anObject  = __webpack_require__(29)
-	  , isObject  = __webpack_require__(30)
-	  , bind      = __webpack_require__(94);
+	var $export    = __webpack_require__(25)
+	  , create     = __webpack_require__(63)
+	  , aFunction  = __webpack_require__(38)
+	  , anObject   = __webpack_require__(29)
+	  , isObject   = __webpack_require__(30)
+	  , fails      = __webpack_require__(24)
+	  , bind       = __webpack_require__(94)
+	  , rConstruct = (__webpack_require__(21).Reflect || {}).construct;
 
-	// MS Edge supports only 2 arguments
+	// MS Edge supports only 2 arguments and argumentsList argument is optional
 	// FF Nightly sets third argument as `new.target`, but does not create `this` from it
-	$export($export.S + $export.F * __webpack_require__(24)(function(){
+	var NEW_TARGET_BUG = fails(function(){
 	  function F(){}
-	  return !(Reflect.construct(function(){}, [], F) instanceof F);
-	}), 'Reflect', {
+	  return !(rConstruct(function(){}, [], F) instanceof F);
+	});
+	var ARGS_BUG = !fails(function(){
+	  rConstruct(function(){});
+	});
+
+	$export($export.S + $export.F * (NEW_TARGET_BUG || ARGS_BUG), 'Reflect', {
 	  construct: function construct(Target, args /*, newTarget*/){
 	    aFunction(Target);
 	    anObject(args);
 	    var newTarget = arguments.length < 3 ? Target : aFunction(arguments[2]);
+	    if(ARGS_BUG && !NEW_TARGET_BUG)return rConstruct(Target, args, newTarget);
 	    if(Target == newTarget){
 	      // w/o altered newTarget, optimization for 0-4 arguments
 	      switch(args.length){
@@ -6228,7 +6219,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 252 */
+/* 251 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.3 Reflect.defineProperty(target, propertyKey, attributes)
@@ -6255,7 +6246,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 253 */
+/* 252 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.4 Reflect.deleteProperty(target, propertyKey)
@@ -6271,7 +6262,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 254 */
+/* 253 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -6285,7 +6276,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    , key;
 	  for(key in iterated)keys.push(key);
 	};
-	__webpack_require__(148)(Enumerate, 'Object', function(){
+	__webpack_require__(147)(Enumerate, 'Object', function(){
 	  var that = this
 	    , keys = that._k
 	    , key;
@@ -6302,7 +6293,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 255 */
+/* 254 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.6 Reflect.get(target, propertyKey [, receiver])
@@ -6328,7 +6319,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S, 'Reflect', {get: get});
 
 /***/ },
-/* 256 */
+/* 255 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.7 Reflect.getOwnPropertyDescriptor(target, propertyKey)
@@ -6343,7 +6334,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 257 */
+/* 256 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.8 Reflect.getPrototypeOf(target)
@@ -6358,7 +6349,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 258 */
+/* 257 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.9 Reflect.has(target, propertyKey)
@@ -6371,7 +6362,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 259 */
+/* 258 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.10 Reflect.isExtensible(target)
@@ -6387,16 +6378,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 260 */
+/* 259 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.11 Reflect.ownKeys(target)
 	var $export = __webpack_require__(25);
 
-	$export($export.S, 'Reflect', {ownKeys: __webpack_require__(261)});
+	$export($export.S, 'Reflect', {ownKeys: __webpack_require__(260)});
 
 /***/ },
-/* 261 */
+/* 260 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// all object keys, includes non-enumerable and symbols
@@ -6411,7 +6402,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 262 */
+/* 261 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.12 Reflect.preventExtensions(target)
@@ -6432,7 +6423,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 263 */
+/* 262 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.13 Reflect.set(target, propertyKey, V [, receiver])
@@ -6468,7 +6459,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S, 'Reflect', {set: set});
 
 /***/ },
-/* 264 */
+/* 263 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// 26.1.14 Reflect.setPrototypeOf(target, proto)
@@ -6488,7 +6479,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 265 */
+/* 264 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -6502,16 +6493,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	});
 
-	__webpack_require__(204)('includes');
+	__webpack_require__(203)('includes');
 
 /***/ },
-/* 266 */
+/* 265 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	// https://github.com/mathiasbynens/String.prototype.at
 	var $export = __webpack_require__(25)
-	  , $at     = __webpack_require__(145)(true);
+	  , $at     = __webpack_require__(144)(true);
 
 	$export($export.P, 'String', {
 	  at: function at(pos){
@@ -6520,13 +6511,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 267 */
+/* 266 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	// https://github.com/tc39/proposal-string-pad-start-end
 	var $export = __webpack_require__(25)
-	  , $pad    = __webpack_require__(268);
+	  , $pad    = __webpack_require__(267);
 
 	$export($export.P, 'String', {
 	  padStart: function padStart(maxLength /*, fillString = ' ' */){
@@ -6535,12 +6526,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 268 */
+/* 267 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/tc39/proposal-string-pad-start-end
 	var toLength = __webpack_require__(54)
-	  , repeat   = __webpack_require__(109)
+	  , repeat   = __webpack_require__(108)
 	  , defined  = __webpack_require__(52);
 
 	module.exports = function(that, maxLength, fillString, left){
@@ -6557,13 +6548,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 269 */
+/* 268 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 	// https://github.com/tc39/proposal-string-pad-start-end
 	var $export = __webpack_require__(25)
-	  , $pad    = __webpack_require__(268);
+	  , $pad    = __webpack_require__(267);
 
 	$export($export.P, 'String', {
 	  padEnd: function padEnd(maxLength /*, fillString = ' ' */){
@@ -6572,7 +6563,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 270 */
+/* 269 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -6584,7 +6575,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}, 'trimStart');
 
 /***/ },
-/* 271 */
+/* 270 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -6596,7 +6587,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}, 'trimEnd');
 
 /***/ },
-/* 272 */
+/* 271 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -6604,8 +6595,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	var $export     = __webpack_require__(25)
 	  , defined     = __webpack_require__(52)
 	  , toLength    = __webpack_require__(54)
-	  , isRegExp    = __webpack_require__(152)
-	  , getFlags    = __webpack_require__(214)
+	  , isRegExp    = __webpack_require__(151)
+	  , getFlags    = __webpack_require__(213)
 	  , RegExpProto = RegExp.prototype;
 
 	var $RegExpStringIterator = function(regexp, string){
@@ -6613,7 +6604,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  this._s = string;
 	};
 
-	__webpack_require__(148)($RegExpStringIterator, 'RegExp String', function next(){
+	__webpack_require__(147)($RegExpStringIterator, 'RegExp String', function next(){
 	  var match = this._r.exec(this._s);
 	  return {value: match, done: match === null};
 	});
@@ -6631,27 +6622,27 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 273 */
+/* 272 */
 /***/ function(module, exports, __webpack_require__) {
 
 	__webpack_require__(44)('asyncIterator');
 
 /***/ },
-/* 274 */
+/* 273 */
 /***/ function(module, exports, __webpack_require__) {
 
 	__webpack_require__(44)('observable');
 
 /***/ },
-/* 275 */
+/* 274 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/tc39/proposal-object-getownpropertydescriptors
 	var $export        = __webpack_require__(25)
-	  , ownKeys        = __webpack_require__(261)
+	  , ownKeys        = __webpack_require__(260)
 	  , toIObject      = __webpack_require__(49)
 	  , gOPD           = __webpack_require__(68)
-	  , createProperty = __webpack_require__(181);
+	  , createProperty = __webpack_require__(180);
 
 	$export($export.S, 'Object', {
 	  getOwnPropertyDescriptors: function getOwnPropertyDescriptors(object){
@@ -6660,19 +6651,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	      , keys    = ownKeys(O)
 	      , result  = {}
 	      , i       = 0
-	      , key, D;
+	      , key;
 	    while(keys.length > i)createProperty(result, key = keys[i++], getDesc(O, key));
 	    return result;
 	  }
 	});
 
 /***/ },
-/* 276 */
+/* 275 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/tc39/proposal-object-values-entries
 	var $export = __webpack_require__(25)
-	  , $values = __webpack_require__(277)(false);
+	  , $values = __webpack_require__(276)(false);
 
 	$export($export.S, 'Object', {
 	  values: function values(it){
@@ -6681,7 +6672,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 277 */
+/* 276 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var getKeys   = __webpack_require__(47)
@@ -6702,12 +6693,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 278 */
+/* 277 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/tc39/proposal-object-values-entries
 	var $export  = __webpack_require__(25)
-	  , $entries = __webpack_require__(277)(true);
+	  , $entries = __webpack_require__(276)(true);
 
 	$export($export.S, 'Object', {
 	  entries: function entries(it){
@@ -6716,7 +6707,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 279 */
+/* 278 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -6726,14 +6717,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , $defineProperty = __webpack_require__(28);
 
 	// B.2.2.2 Object.prototype.__defineGetter__(P, getter)
-	__webpack_require__(23) && $export($export.P + __webpack_require__(280), 'Object', {
+	__webpack_require__(23) && $export($export.P + __webpack_require__(279), 'Object', {
 	  __defineGetter__: function __defineGetter__(P, getter){
 	    $defineProperty.f(toObject(this), P, {get: aFunction(getter), enumerable: true, configurable: true});
 	  }
 	});
 
 /***/ },
-/* 280 */
+/* 279 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// Forced replacement prototype accessors methods
@@ -6745,7 +6736,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 281 */
+/* 280 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -6755,9 +6746,32 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , $defineProperty = __webpack_require__(28);
 
 	// B.2.2.3 Object.prototype.__defineSetter__(P, setter)
-	__webpack_require__(23) && $export($export.P + __webpack_require__(280), 'Object', {
+	__webpack_require__(23) && $export($export.P + __webpack_require__(279), 'Object', {
 	  __defineSetter__: function __defineSetter__(P, setter){
 	    $defineProperty.f(toObject(this), P, {set: aFunction(setter), enumerable: true, configurable: true});
+	  }
+	});
+
+/***/ },
+/* 281 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var $export                  = __webpack_require__(25)
+	  , toObject                 = __webpack_require__(75)
+	  , toPrimitive              = __webpack_require__(33)
+	  , getPrototypeOf           = __webpack_require__(76)
+	  , getOwnPropertyDescriptor = __webpack_require__(68).f;
+
+	// B.2.2.4 Object.prototype.__lookupGetter__(P)
+	__webpack_require__(23) && $export($export.P + __webpack_require__(279), 'Object', {
+	  __lookupGetter__: function __lookupGetter__(P){
+	    var O = toObject(this)
+	      , K = toPrimitive(P, true)
+	      , D;
+	    do {
+	      if(D = getOwnPropertyDescriptor(O, K))return D.get;
+	    } while(O = getPrototypeOf(O));
 	  }
 	});
 
@@ -6772,31 +6786,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , getPrototypeOf           = __webpack_require__(76)
 	  , getOwnPropertyDescriptor = __webpack_require__(68).f;
 
-	// B.2.2.4 Object.prototype.__lookupGetter__(P)
-	__webpack_require__(23) && $export($export.P + __webpack_require__(280), 'Object', {
-	  __lookupGetter__: function __lookupGetter__(P){
-	    var O = toObject(this)
-	      , K = toPrimitive(P, true)
-	      , D;
-	    do {
-	      if(D = getOwnPropertyDescriptor(O, K))return D.get;
-	    } while(O = getPrototypeOf(O));
-	  }
-	});
-
-/***/ },
-/* 283 */
-/***/ function(module, exports, __webpack_require__) {
-
-	'use strict';
-	var $export                  = __webpack_require__(25)
-	  , toObject                 = __webpack_require__(75)
-	  , toPrimitive              = __webpack_require__(33)
-	  , getPrototypeOf           = __webpack_require__(76)
-	  , getOwnPropertyDescriptor = __webpack_require__(68).f;
-
 	// B.2.2.5 Object.prototype.__lookupSetter__(P)
-	__webpack_require__(23) && $export($export.P + __webpack_require__(280), 'Object', {
+	__webpack_require__(23) && $export($export.P + __webpack_require__(279), 'Object', {
 	  __lookupSetter__: function __lookupSetter__(P){
 	    var O = toObject(this)
 	      , K = toPrimitive(P, true)
@@ -6808,21 +6799,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 284 */
+/* 283 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/DavidBruant/Map-Set.prototype.toJSON
 	var $export  = __webpack_require__(25);
 
-	$export($export.P + $export.R, 'Map', {toJSON: __webpack_require__(285)('Map')});
+	$export($export.P + $export.R, 'Map', {toJSON: __webpack_require__(284)('Map')});
 
 /***/ },
-/* 285 */
+/* 284 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/DavidBruant/Map-Set.prototype.toJSON
 	var classof = __webpack_require__(92)
-	  , from    = __webpack_require__(286);
+	  , from    = __webpack_require__(285);
 	module.exports = function(NAME){
 	  return function toJSON(){
 	    if(classof(this) != NAME)throw TypeError(NAME + "#toJSON isn't generic");
@@ -6831,7 +6822,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 286 */
+/* 285 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var forOf = __webpack_require__(223);
@@ -6844,16 +6835,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 287 */
+/* 286 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/DavidBruant/Map-Set.prototype.toJSON
 	var $export  = __webpack_require__(25);
 
-	$export($export.P + $export.R, 'Set', {toJSON: __webpack_require__(285)('Set')});
+	$export($export.P + $export.R, 'Set', {toJSON: __webpack_require__(284)('Set')});
 
 /***/ },
-/* 288 */
+/* 287 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/ljharb/proposal-global
@@ -6862,7 +6853,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	$export($export.S, 'System', {global: __webpack_require__(21)});
 
 /***/ },
-/* 289 */
+/* 288 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/ljharb/proposal-is-error
@@ -6876,7 +6867,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 290 */
+/* 289 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -6892,7 +6883,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 291 */
+/* 290 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -6908,7 +6899,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 292 */
+/* 291 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -6929,7 +6920,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 293 */
+/* 292 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -6950,10 +6941,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 294 */
+/* 293 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var metadata                  = __webpack_require__(295)
+	var metadata                  = __webpack_require__(294)
 	  , anObject                  = __webpack_require__(29)
 	  , toMetaKey                 = metadata.key
 	  , ordinaryDefineOwnMetadata = metadata.set;
@@ -6963,7 +6954,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}});
 
 /***/ },
-/* 295 */
+/* 294 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var Map     = __webpack_require__(228)
@@ -7019,10 +7010,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 296 */
+/* 295 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var metadata               = __webpack_require__(295)
+	var metadata               = __webpack_require__(294)
 	  , anObject               = __webpack_require__(29)
 	  , toMetaKey              = metadata.key
 	  , getOrCreateMetadataMap = metadata.map
@@ -7039,10 +7030,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	}});
 
 /***/ },
-/* 297 */
+/* 296 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var metadata               = __webpack_require__(295)
+	var metadata               = __webpack_require__(294)
 	  , anObject               = __webpack_require__(29)
 	  , getPrototypeOf         = __webpack_require__(76)
 	  , ordinaryHasOwnMetadata = metadata.has
@@ -7061,12 +7052,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	}});
 
 /***/ },
-/* 298 */
+/* 297 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var Set                     = __webpack_require__(231)
-	  , from                    = __webpack_require__(286)
-	  , metadata                = __webpack_require__(295)
+	  , from                    = __webpack_require__(285)
+	  , metadata                = __webpack_require__(294)
 	  , anObject                = __webpack_require__(29)
 	  , getPrototypeOf          = __webpack_require__(76)
 	  , ordinaryOwnMetadataKeys = metadata.keys
@@ -7085,10 +7076,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	}});
 
 /***/ },
-/* 299 */
+/* 298 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var metadata               = __webpack_require__(295)
+	var metadata               = __webpack_require__(294)
 	  , anObject               = __webpack_require__(29)
 	  , ordinaryGetOwnMetadata = metadata.get
 	  , toMetaKey              = metadata.key;
@@ -7099,10 +7090,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	}});
 
 /***/ },
-/* 300 */
+/* 299 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var metadata                = __webpack_require__(295)
+	var metadata                = __webpack_require__(294)
 	  , anObject                = __webpack_require__(29)
 	  , ordinaryOwnMetadataKeys = metadata.keys
 	  , toMetaKey               = metadata.key;
@@ -7112,10 +7103,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	}});
 
 /***/ },
-/* 301 */
+/* 300 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var metadata               = __webpack_require__(295)
+	var metadata               = __webpack_require__(294)
 	  , anObject               = __webpack_require__(29)
 	  , getPrototypeOf         = __webpack_require__(76)
 	  , ordinaryHasOwnMetadata = metadata.has
@@ -7133,10 +7124,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	}});
 
 /***/ },
-/* 302 */
+/* 301 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var metadata               = __webpack_require__(295)
+	var metadata               = __webpack_require__(294)
 	  , anObject               = __webpack_require__(29)
 	  , ordinaryHasOwnMetadata = metadata.has
 	  , toMetaKey              = metadata.key;
@@ -7147,10 +7138,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	}});
 
 /***/ },
-/* 303 */
+/* 302 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var metadata                  = __webpack_require__(295)
+	var metadata                  = __webpack_require__(294)
 	  , anObject                  = __webpack_require__(29)
 	  , aFunction                 = __webpack_require__(38)
 	  , toMetaKey                 = metadata.key
@@ -7167,7 +7158,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}});
 
 /***/ },
-/* 304 */
+/* 303 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-09/sept-25.md#510-globalasap-for-enqueuing-a-microtask
@@ -7184,7 +7175,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 305 */
+/* 304 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -7196,7 +7187,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  , OBSERVABLE  = __webpack_require__(42)('observable')
 	  , aFunction   = __webpack_require__(38)
 	  , anObject    = __webpack_require__(29)
-	  , anInstance  = __webpack_require__(107)
+	  , anInstance  = __webpack_require__(222)
 	  , redefineAll = __webpack_require__(227)
 	  , hide        = __webpack_require__(27)
 	  , forOf       = __webpack_require__(223)
@@ -7385,17 +7376,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	$export($export.G, {Observable: $Observable});
 
-	__webpack_require__(210)('Observable');
+	__webpack_require__(209)('Observable');
 
 /***/ },
-/* 306 */
+/* 305 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// ie9- setTimeout & setInterval additional parameters fix
 	var global     = __webpack_require__(21)
 	  , $export    = __webpack_require__(25)
 	  , invoke     = __webpack_require__(95)
-	  , partial    = __webpack_require__(307)
+	  , partial    = __webpack_require__(306)
 	  , navigator  = global.navigator
 	  , MSIE       = !!navigator && /MSIE .\./.test(navigator.userAgent); // <- dirty ie9- check
 	var wrap = function(set){
@@ -7413,11 +7404,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 307 */
+/* 306 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	var path      = __webpack_require__(308)
+	var path      = __webpack_require__(307)
 	  , invoke    = __webpack_require__(95)
 	  , aFunction = __webpack_require__(38);
 	module.exports = function(/* ...pargs */){
@@ -7441,13 +7432,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 308 */
+/* 307 */
 /***/ function(module, exports, __webpack_require__) {
 
 	module.exports = __webpack_require__(21);
 
 /***/ },
-/* 309 */
+/* 308 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var $export = __webpack_require__(25)
@@ -7458,14 +7449,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 310 */
+/* 309 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var $iterators    = __webpack_require__(211)
+	var $iterators    = __webpack_require__(210)
 	  , redefine      = __webpack_require__(35)
 	  , global        = __webpack_require__(21)
 	  , hide          = __webpack_require__(27)
-	  , Iterators     = __webpack_require__(147)
+	  , Iterators     = __webpack_require__(146)
 	  , wks           = __webpack_require__(42)
 	  , ITERATOR      = wks('iterator')
 	  , TO_STRING_TAG = wks('toStringTag')
@@ -7485,7 +7476,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 311 */
+/* 310 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global, process) {/**
@@ -8146,10 +8137,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  typeof self === "object" ? self : this
 	);
 
-	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }()), __webpack_require__(312)))
+	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }()), __webpack_require__(311)))
 
 /***/ },
-/* 312 */
+/* 311 */
 /***/ function(module, exports) {
 
 	// shim for using process in browser
@@ -8204,7 +8195,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (draining) {
 	        return;
 	    }
-	    var timeout = cachedSetTimeout(cleanUpNextTick);
+	    var timeout = cachedSetTimeout.call(null, cleanUpNextTick);
 	    draining = true;
 
 	    var len = queue.length;
@@ -8221,7 +8212,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	    currentQueue = null;
 	    draining = false;
-	    cachedClearTimeout(timeout);
+	    cachedClearTimeout.call(null, timeout);
 	}
 
 	process.nextTick = function (fun) {
@@ -8233,7 +8224,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	    queue.push(new Item(fun, args));
 	    if (queue.length === 1 && !draining) {
-	        cachedSetTimeout(drainQueue, 0);
+	        cachedSetTimeout.call(null, drainQueue, 0);
 	    }
 	};
 
@@ -8274,25 +8265,25 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ },
-/* 313 */
+/* 312 */
 /***/ function(module, exports, __webpack_require__) {
 
-	__webpack_require__(314);
+	__webpack_require__(313);
 	module.exports = __webpack_require__(26).RegExp.escape;
 
 /***/ },
-/* 314 */
+/* 313 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// https://github.com/benjamingr/RexExp.escape
 	var $export = __webpack_require__(25)
-	  , $re     = __webpack_require__(315)(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+	  , $re     = __webpack_require__(314)(/[\\^$*+?.()|[\]{}]/g, '\\$&');
 
 	$export($export.S, 'RegExp', {escape: function escape(it){ return $re(it); }});
 
 
 /***/ },
-/* 315 */
+/* 314 */
 /***/ function(module, exports) {
 
 	module.exports = function(regExp, replace){
@@ -8305,37 +8296,37 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 316 */
+/* 315 */
 /***/ function(module, exports) {
 
 	module.exports = require("chai");
 
 /***/ },
-/* 317 */
+/* 316 */
 /***/ function(module, exports) {
 
 	module.exports = require("sinon");
 
 /***/ },
-/* 318 */
+/* 317 */
 /***/ function(module, exports) {
 
 	module.exports = require("sinon-chai");
 
 /***/ },
-/* 319 */
+/* 318 */
 /***/ function(module, exports) {
 
 	module.exports = require("chai-enzyme");
 
 /***/ },
-/* 320 */
+/* 319 */
 /***/ function(module, exports) {
 
 	module.exports = require("enzyme");
 
 /***/ },
-/* 321 */
+/* 320 */
 /***/ function(module, exports) {
 
 	module.exports = require("jsdom");

--- a/lib/modules/Server.js
+++ b/lib/modules/Server.js
@@ -77,6 +77,9 @@ export default config => {
     }
   };
 
+  // set up server routes before setting up shared routes
+  getServerRouter(router);
+
   for (let route of routes) {
     let [path, handler] = route;
     for (let method of values(METHODS)) {
@@ -86,7 +89,7 @@ export default config => {
     }
   }
 
-  getServerRouter(router);
+  // hook up all the middleware to the koa instance
   preRouteServerMiddleware.forEach(m => server.use(m));
   server.use(bodyparser);
   server.use(router.routes());

--- a/lib/modules/actions.js
+++ b/lib/modules/actions.js
@@ -11,9 +11,17 @@ export const setPage = (url, { urlParams={}, queryParams={}, hashParams={}, refe
   payload: { url, urlParams, queryParams, hashParams, referrer },
 });
 
-export const gotoPageIndex = pageIndex => ({
+export const gotoPageIndex = (
+  pageIndex,
+  pathName,
+  {
+    queryParams={},
+    hashParams={},
+    referrer='',
+  }={}
+) => ({
   type: GOTO_PAGE_INDEX,
-  payload: { pageIndex },
+  payload: { pageIndex, pathName, queryParams, hashParams, referrer },
 });
 
 export const navigateToUrl = (

--- a/lib/modules/components.js
+++ b/lib/modules/components.js
@@ -251,7 +251,7 @@ const getValues = form => {
       switch (el.type) {
         case 'checkbox': {
           if (!values[el.name]) { values[el.name] = []; }
-          if (el.value) { values[el.name].push(el.value); }
+          if (el.checked) { values[el.name].push(el.value); }
           break;
         }
         case 'select-multiple': {

--- a/lib/modules/components.js
+++ b/lib/modules/components.js
@@ -364,9 +364,10 @@ export class _UrlSync extends React.Component {
       const currentQuery = extractQuery(self.location.search);
       const currentHash = {}; // TODO: address how hashes are displayed
       let pageIndex = -1;
+      let hist = {};
 
       for (let i = this.props.history.length - 1; i >= 0; i--) {
-        const hist = this.props.history[i];
+        hist = this.props.history[i];
         if (hist.url === pathname && isEqual(hist.queryParams, currentQuery)) {
           pageIndex = i;
           break;
@@ -374,7 +375,8 @@ export class _UrlSync extends React.Component {
       }
 
       if (pageIndex > -1) {
-        this.props.gotoPageIndex(pageIndex);
+        const { url, queryParams, hashParams, urlParams, referrer } = hist;
+        this.props.gotoPageIndex(pageIndex, url, { queryParams, hashParams, urlParams, referrer });
       } else {
         // can't find the url, just navigate
         this.props.navigateToPage(pathname, currentQuery, currentHash);
@@ -415,7 +417,7 @@ const urlSelector = createSelector(
 );
 
 const urlDispatcher = dispatch => ({
-  gotoPageIndex: index => dispatch(navigationActions.gotoPageIndex(index)),
+  gotoPageIndex: (index, url, data) => dispatch(navigationActions.gotoPageIndex(index, url, data)),
   navigateToPage: (url, queryParams, hashParams) => dispatch(
     navigationActions.navigateToUrl(METHODS.GET, url, { queryParams, hashParams })
   ),

--- a/lib/modules/navigationMiddleware.js
+++ b/lib/modules/navigationMiddleware.js
@@ -2,7 +2,7 @@ import pathToRegex from 'path-to-regexp';
 import { METHODS } from './router';
 import * as actions from './actions';
 
-export function parseRoute(path, routes) {
+export function matchRoute(path, routes) {
   let route;
 
   for (route of routes) {
@@ -19,7 +19,7 @@ export function parseRoute(path, routes) {
 const findAndCallHandler = (store, routes, shouldSetPage, data) => {
   const { method, pathName, queryParams, hashParams, bodyParams, referrer } = data;
   const { dispatch, getState } = store;
-  const route = parseRoute(pathName, routes);
+  const route = matchRoute(pathName, routes);
 
   if (route) {
     const { handler, reg, result } = route;

--- a/lib/modules/navigationMiddleware.js
+++ b/lib/modules/navigationMiddleware.js
@@ -56,20 +56,20 @@ const findAndCallHandler = (store, routes, shouldSetPage, data) => {
 export default {
   create(routes) {
     return store => next => action => {
-      if (action.type === actions.NAVIGATE_TO_URL) {
-        next(action);
-        return next(findAndCallHandler(store, routes, true, action.payload));
+      switch (action.type) {
+        case actions.NAVIGATE_TO_URL: {
+          next(action);
+          return next(findAndCallHandler(store, routes, true, action.payload));
+        }
+        case actions.GOTO_PAGE_INDEX: {
+          next(action);
+          return next(findAndCallHandler(store, routes, false, {
+            ...action.payload,
+            method: METHODS.GET,
+          }));
+        }
+        default: return next(action);
       }
-
-      if (action.type === actions.GOTO_PAGE_INDEX) {
-        next(action);
-        return next(findAndCallHandler(store, routes, false, {
-          ...action.payload,
-          method: METHODS.GET,
-        }));
-      }
-
-      return next(action);
     };
   },
 };

--- a/lib/modules/navigationMiddleware.js
+++ b/lib/modules/navigationMiddleware.js
@@ -2,7 +2,7 @@ import pathToRegex from 'path-to-regexp';
 import { METHODS } from './router';
 import * as actions from './actions';
 
-export function parseRoute (path, routes) {
+export function parseRoute(path, routes) {
   let route;
 
   for (route of routes) {
@@ -16,44 +16,57 @@ export function parseRoute (path, routes) {
   }
 }
 
+const findAndCallHandler = (store, routes, shouldSetPage, data) => {
+  const { method, pathName, queryParams, hashParams, bodyParams, referrer } = data;
+  const { dispatch, getState } = store;
+  const route = parseRoute(pathName, routes);
+
+  if (route) {
+    const { handler, reg, result } = route;
+    const urlParams = reg.keys.reduce((prev, cur, index) => ({
+      ...prev,
+      [cur.name]: result[index + 1],
+    }), {});
+
+    if (shouldSetPage && method === METHODS.GET) {
+      dispatch(actions.setPage(pathName, {
+        urlParams,
+        queryParams,
+        hashParams,
+        referrer,
+      }));
+    }
+
+    const h = new handler(
+      pathName,
+      urlParams,
+      queryParams,
+      hashParams,
+      bodyParams,
+      dispatch,
+      getState
+    );
+
+    return h[method].bind(h);
+  }
+
+  return new Error(`No route found for ${method} ${pathName}`);
+};
+
 export default {
   create(routes) {
     return store => next => action => {
       if (action.type === actions.NAVIGATE_TO_URL) {
-        const { method, pathName, queryParams, hashParams, bodyParams, referrer } = action.payload;
-        const { dispatch, getState } = store;
-        const route = parseRoute(pathName, routes);
+        next(action);
+        return next(findAndCallHandler(store, routes, true, action.payload));
+      }
 
-        if (route) {
-          const { handler, reg, result } = route;
-          const urlParams = reg.keys.reduce((prev, cur, index) => ({
-            ...prev,
-            [cur.name]: result[index + 1],
-          }), {});
-
-          if (method === METHODS.GET) {
-            dispatch(actions.setPage(pathName, {
-              urlParams,
-              queryParams,
-              hashParams,
-              referrer,
-            }));
-          }
-
-          const h = new handler(
-            pathName,
-            urlParams,
-            queryParams,
-            hashParams,
-            bodyParams,
-            dispatch,
-            getState
-          );
-
-          return next(h[method].bind(h));
-        }
-
-        return next(new Error(`No route found for ${method} ${pathName}`));
+      if (action.type === actions.GOTO_PAGE_INDEX) {
+        next(action);
+        return next(findAndCallHandler(store, routes, false, {
+          ...action.payload,
+          method: METHODS.GET,
+        }));
       }
 
       return next(action);

--- a/navigationMiddleware.js
+++ b/navigationMiddleware.js
@@ -67,7 +67,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-	exports.parseRoute = parseRoute;
+	exports.matchRoute = matchRoute;
 
 	var _pathToRegexp = __webpack_require__(321);
 
@@ -85,7 +85,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-	function parseRoute(path, routes) {
+	function matchRoute(path, routes) {
 	  var route = void 0;
 
 	  var _iteratorNormalCompletion = true;
@@ -135,7 +135,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var dispatch = store.dispatch;
 	  var getState = store.getState;
 
-	  var route = parseRoute(pathName, routes);
+	  var route = matchRoute(pathName, routes);
 
 	  if (route) {
 	    var _ret = function () {

--- a/navigationMiddleware.js
+++ b/navigationMiddleware.js
@@ -7,7 +7,7 @@
 		exports["navigationMiddleware.js"] = factory(require("./actions.js"), require("./router.js"), require("path-to-regexp"));
 	else
 		root["navigationMiddleware.js"] = factory(root["./actions.js"], root["./router.js"], root["path-to-regexp"]);
-})(this, function(__WEBPACK_EXTERNAL_MODULE_13__, __WEBPACK_EXTERNAL_MODULE_15__, __WEBPACK_EXTERNAL_MODULE_322__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE_13__, __WEBPACK_EXTERNAL_MODULE_15__, __WEBPACK_EXTERNAL_MODULE_321__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -69,7 +69,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	exports.parseRoute = parseRoute;
 
-	var _pathToRegexp = __webpack_require__(322);
+	var _pathToRegexp = __webpack_require__(321);
 
 	var _pathToRegexp2 = _interopRequireDefault(_pathToRegexp);
 
@@ -125,54 +125,65 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	}
 
+	var findAndCallHandler = function findAndCallHandler(store, routes, shouldSetPage, data) {
+	  var method = data.method;
+	  var pathName = data.pathName;
+	  var queryParams = data.queryParams;
+	  var hashParams = data.hashParams;
+	  var bodyParams = data.bodyParams;
+	  var referrer = data.referrer;
+	  var dispatch = store.dispatch;
+	  var getState = store.getState;
+
+	  var route = parseRoute(pathName, routes);
+
+	  if (route) {
+	    var _ret = function () {
+	      var handler = route.handler;
+	      var reg = route.reg;
+	      var result = route.result;
+
+	      var urlParams = reg.keys.reduce(function (prev, cur, index) {
+	        return _extends({}, prev, _defineProperty({}, cur.name, result[index + 1]));
+	      }, {});
+
+	      if (shouldSetPage && method === _router.METHODS.GET) {
+	        dispatch(actions.setPage(pathName, {
+	          urlParams: urlParams,
+	          queryParams: queryParams,
+	          hashParams: hashParams,
+	          referrer: referrer
+	        }));
+	      }
+
+	      var h = new handler(pathName, urlParams, queryParams, hashParams, bodyParams, dispatch, getState);
+
+	      return {
+	        v: h[method].bind(h)
+	      };
+	    }();
+
+	    if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+	  }
+
+	  return new Error('No route found for ' + method + ' ' + pathName);
+	};
+
 	exports.default = {
 	  create: function create(routes) {
 	    return function (store) {
 	      return function (next) {
 	        return function (action) {
 	          if (action.type === actions.NAVIGATE_TO_URL) {
-	            var _action$payload = action.payload;
-	            var method = _action$payload.method;
-	            var pathName = _action$payload.pathName;
-	            var queryParams = _action$payload.queryParams;
-	            var hashParams = _action$payload.hashParams;
-	            var bodyParams = _action$payload.bodyParams;
-	            var referrer = _action$payload.referrer;
-	            var dispatch = store.dispatch;
-	            var getState = store.getState;
+	            next(action);
+	            return next(findAndCallHandler(store, routes, true, action.payload));
+	          }
 
-	            var route = parseRoute(pathName, routes);
-
-	            if (route) {
-	              var _ret = function () {
-	                var handler = route.handler;
-	                var reg = route.reg;
-	                var result = route.result;
-
-	                var urlParams = reg.keys.reduce(function (prev, cur, index) {
-	                  return _extends({}, prev, _defineProperty({}, cur.name, result[index + 1]));
-	                }, {});
-
-	                if (method === _router.METHODS.GET) {
-	                  dispatch(actions.setPage(pathName, {
-	                    urlParams: urlParams,
-	                    queryParams: queryParams,
-	                    hashParams: hashParams,
-	                    referrer: referrer
-	                  }));
-	                }
-
-	                var h = new handler(pathName, urlParams, queryParams, hashParams, bodyParams, dispatch, getState);
-
-	                return {
-	                  v: next(h[method].bind(h))
-	                };
-	              }();
-
-	              if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
-	            }
-
-	            return next(new Error('No route found for ' + method + ' ' + pathName));
+	          if (action.type === actions.GOTO_PAGE_INDEX) {
+	            next(action);
+	            return next(findAndCallHandler(store, routes, false, _extends({}, action.payload, {
+	              method: _router.METHODS.GET
+	            })));
 	          }
 
 	          return next(action);
@@ -198,7 +209,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ },
 
-/***/ 322:
+/***/ 321:
 /***/ function(module, exports) {
 
 	module.exports = require("path-to-regexp");

--- a/navigationMiddleware.js
+++ b/navigationMiddleware.js
@@ -174,19 +174,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return function (store) {
 	      return function (next) {
 	        return function (action) {
-	          if (action.type === actions.NAVIGATE_TO_URL) {
-	            next(action);
-	            return next(findAndCallHandler(store, routes, true, action.payload));
+	          switch (action.type) {
+	            case actions.NAVIGATE_TO_URL:
+	              {
+	                next(action);
+	                return next(findAndCallHandler(store, routes, true, action.payload));
+	              }
+	            case actions.GOTO_PAGE_INDEX:
+	              {
+	                next(action);
+	                return next(findAndCallHandler(store, routes, false, _extends({}, action.payload, {
+	                  method: _router.METHODS.GET
+	                })));
+	              }
+	            default:
+	              return next(action);
 	          }
-
-	          if (action.type === actions.GOTO_PAGE_INDEX) {
-	            next(action);
-	            return next(findAndCallHandler(store, routes, false, _extends({}, action.payload, {
-	              method: _router.METHODS.GET
-	            })));
-	          }
-
-	          return next(action);
 	        };
 	      };
 	    };

--- a/pageUtils.js
+++ b/pageUtils.js
@@ -7,7 +7,7 @@
 		exports["pageUtils.js"] = factory(require("./merge.js"));
 	else
 		root["pageUtils.js"] = factory(root["./merge.js"]);
-})(this, function(__WEBPACK_EXTERNAL_MODULE_323__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE_322__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -66,7 +66,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-	var _merge = __webpack_require__(323);
+	var _merge = __webpack_require__(322);
 
 	var _merge2 = _interopRequireDefault(_merge);
 
@@ -135,10 +135,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ },
 
-/***/ 323:
+/***/ 322:
 /***/ function(module, exports) {
 
-	module.exports = __WEBPACK_EXTERNAL_MODULE_323__;
+	module.exports = __WEBPACK_EXTERNAL_MODULE_322__;
 
 /***/ }
 

--- a/platform.js
+++ b/platform.js
@@ -7,7 +7,7 @@
 		exports["platform.js"] = factory(require("./navigationMiddleware.js"), require("./reducer.js"), require("./actions.js"), require("./router.js"), require("./merge.js"), require("./Client.js"), require("./components.js"), require("./url.js"), require("./Server.js"));
 	else
 		root["platform.js"] = factory(root["./navigationMiddleware.js"], root["./reducer.js"], root["./actions.js"], root["./router.js"], root["./merge.js"], root["./Client.js"], root["./components.js"], root["./url.js"], root["./Server.js"]);
-})(this, function(__WEBPACK_EXTERNAL_MODULE_6__, __WEBPACK_EXTERNAL_MODULE_7__, __WEBPACK_EXTERNAL_MODULE_13__, __WEBPACK_EXTERNAL_MODULE_15__, __WEBPACK_EXTERNAL_MODULE_323__, __WEBPACK_EXTERNAL_MODULE_324__, __WEBPACK_EXTERNAL_MODULE_325__, __WEBPACK_EXTERNAL_MODULE_326__, __WEBPACK_EXTERNAL_MODULE_327__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE_6__, __WEBPACK_EXTERNAL_MODULE_7__, __WEBPACK_EXTERNAL_MODULE_13__, __WEBPACK_EXTERNAL_MODULE_15__, __WEBPACK_EXTERNAL_MODULE_322__, __WEBPACK_EXTERNAL_MODULE_323__, __WEBPACK_EXTERNAL_MODULE_324__, __WEBPACK_EXTERNAL_MODULE_325__, __WEBPACK_EXTERNAL_MODULE_326__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -66,15 +66,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var actions = _interopRequireWildcard(_actions);
 
-	var _Client = __webpack_require__(324);
+	var _Client = __webpack_require__(323);
 
 	var _Client2 = _interopRequireDefault(_Client);
 
-	var _components = __webpack_require__(325);
+	var _components = __webpack_require__(324);
 
 	var _components2 = _interopRequireDefault(_components);
 
-	var _merge = __webpack_require__(323);
+	var _merge = __webpack_require__(322);
 
 	var _merge2 = _interopRequireDefault(_merge);
 
@@ -82,7 +82,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _navigationMiddleware2 = _interopRequireDefault(_navigationMiddleware);
 
-	var _url = __webpack_require__(326);
+	var _url = __webpack_require__(325);
 
 	var _url2 = _interopRequireDefault(_url);
 
@@ -94,7 +94,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _router2 = _interopRequireDefault(_router);
 
-	var _Server = __webpack_require__(327);
+	var _Server = __webpack_require__(326);
 
 	var _Server2 = _interopRequireDefault(_Server);
 
@@ -153,6 +153,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ },
 
+/***/ 322:
+/***/ function(module, exports) {
+
+	module.exports = __WEBPACK_EXTERNAL_MODULE_322__;
+
+/***/ },
+
 /***/ 323:
 /***/ function(module, exports) {
 
@@ -178,13 +185,6 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports) {
 
 	module.exports = __WEBPACK_EXTERNAL_MODULE_326__;
-
-/***/ },
-
-/***/ 327:
-/***/ function(module, exports) {
-
-	module.exports = __WEBPACK_EXTERNAL_MODULE_327__;
 
 /***/ }
 

--- a/reducer.js
+++ b/reducer.js
@@ -7,7 +7,7 @@
 		exports["reducer.js"] = factory(require("lodash/lang"), require("./actions.js"), require("./pageUtils.js"), require("./merge.js"));
 	else
 		root["reducer.js"] = factory(root["lodash/lang"], root["./actions.js"], root["./pageUtils.js"], root["./merge.js"]);
-})(this, function(__WEBPACK_EXTERNAL_MODULE_12__, __WEBPACK_EXTERNAL_MODULE_13__, __WEBPACK_EXTERNAL_MODULE_14__, __WEBPACK_EXTERNAL_MODULE_323__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE_12__, __WEBPACK_EXTERNAL_MODULE_13__, __WEBPACK_EXTERNAL_MODULE_14__, __WEBPACK_EXTERNAL_MODULE_322__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -65,7 +65,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _lang = __webpack_require__(12);
 
-	var _merge = __webpack_require__(323);
+	var _merge = __webpack_require__(322);
 
 	var _merge2 = _interopRequireDefault(_merge);
 
@@ -161,10 +161,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ },
 
-/***/ 323:
+/***/ 322:
 /***/ function(module, exports) {
 
-	module.exports = __WEBPACK_EXTERNAL_MODULE_323__;
+	module.exports = __WEBPACK_EXTERNAL_MODULE_322__;
 
 /***/ }
 

--- a/url.js
+++ b/url.js
@@ -7,7 +7,7 @@
 		exports["url.js"] = factory(require("react"), require("react-redux"), require("reselect"), require("path-to-regexp"));
 	else
 		root["url.js"] = factory(root["react"], root["react-redux"], root["reselect"], root["path-to-regexp"]);
-})(this, function(__WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_5__, __WEBPACK_EXTERNAL_MODULE_16__, __WEBPACK_EXTERNAL_MODULE_322__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_5__, __WEBPACK_EXTERNAL_MODULE_16__, __WEBPACK_EXTERNAL_MODULE_321__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -72,7 +72,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _reselect = __webpack_require__(16);
 
-	var _pathToRegexp = __webpack_require__(322);
+	var _pathToRegexp = __webpack_require__(321);
 
 	var _pathToRegexp2 = _interopRequireDefault(_pathToRegexp);
 
@@ -244,7 +244,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ },
 
-/***/ 322:
+/***/ 321:
 /***/ function(module, exports) {
 
 	module.exports = require("path-to-regexp");


### PR DESCRIPTION
Two commits, will go in individually.

The first ensures that the handlers will be called even on popstate events. This way, we push the logic of determining whether or not to make api calls to the handlers itself.

The second re-orders the server and shared routes. Server routes are now first, and shared routes come after.

Apologies for the insane diff, I still haven't fixed not checking in compiled code.

:eyeglasses: @schwers @phil303
