### PR TITLE
Set X-Frame-Options to SAMEORIGIN

### DIFF
--- a/lib/modules/Server.js
+++ b/lib/modules/Server.js
@@ -72,6 +72,7 @@ export default config => {
         ctx.redirect('/');
       }
     } else {
+      ctx.set('X-Frame-Options', 'SAMEORIGIN');
       ctx.body = template(state, store);
       ctx.status = state.platform.currentPage.status;
     }


### PR DESCRIPTION
In order to make our platform apps a little safer, enforce a same origin
policy for frames (iframes, frames, or objects). In other words, only
hosts of the same domain as the app in question will be able to serve
the app via an iframe. This prevents clickjacking based attacks.

The other options here are DENY or ALLOW-FROM <some origin>. The former
disallows the app from being displayed in iframes entirely, which feels
overly restrictive right now. The latter authors to specify the origins
explicitly, which is a nice feature but we don't have a strong use case
for right now but maybe in the future.

:eyeglasses: @schwers @nramadas @prashtx @dwick
