### PR TITLE
Fix urlFromPage error with empty queryParams/hashParams

### DIFF
--- a/lib/modules/pageUtils.js
+++ b/lib/modules/pageUtils.js
@@ -19,9 +19,9 @@ export const extractQuery = str => {
 
 export const createQuery = dict => {
   const qs = Object.keys(dict)
-              .filter(k => typeof dict[k] !== 'undefined')
-              .map(k => `${k}=${encodeURIComponent(dict[k])}`)
-              .join('&');
+                   .filter(k => typeof dict[k] !== 'undefined')
+                   .map(k => `${k}=${encodeURIComponent(dict[k])}`)
+                   .join('&');
 
   return `?${qs}`;
 };
@@ -31,8 +31,8 @@ export const createHash = str => {
 };
 
 export const urlFromPage = (page, mergePage) => {
-  const { queryParams, hashParams, url } = mergePage ? merge(page, mergePage) : page;
-  const queryString = Object.keys(queryParams).length ? `${createQuery(queryParams)}` : '';
-  const hashString = Object.keys(hashParams).length ? `${createHash(hashParams)}` : '';
+  const { url, queryParams={}, hashParams={} } = mergePage ? merge(page, mergePage) : page;
+  const queryString = Object.keys(queryParams).length ? createQuery(queryParams) : '';
+  const hashString = Object.keys(hashParams).length ? createHash(hashParams) : '';
   return `${url}${queryString}${hashString}`;
 };


### PR DESCRIPTION
When those parameters aren't set, this function has
an error. It seems it's happening because of another
error, but that's hidden behind this one at the moment.

👓  @schwers @phil303 @nramadas 
