### PR TITLE
Throw an Error when a handler doesn't have a method

### DIFF
--- a/lib/modules/navigationMiddleware.js
+++ b/lib/modules/navigationMiddleware.js
@@ -57,10 +57,13 @@ const findAndCallHandler = (store, routes, shouldSetPage, data) => {
       getState
     );
 
+    if (h[method] === undefined) {
+      throw new Error(`No method found for ${method.toUpperCase()} ${pathName}`);
+    }
     return h[method].bind(h);
   }
 
-  return new Error(`No route found for ${method} ${pathName}`);
+  throw new Error(`No route found for ${method.toUpperCase()} ${pathName}`);
 };
 
 export default {


### PR DESCRIPTION
When a route is a found but its handler doesn't have
the specific method being requested, we currently see

"TypeError: Cannot read property 'bind' of undefined"

Because the h[method] is resolving as undefined.
Instead, get a bit more information on the exact
path and method being attempted:

"Error: No method found for GET /foo/bar"

👓  @schwers @phil303 @nramadas 
