### PR TITLE
Support the head method and head requests

### DIFF
--- a/lib/modules/Server.js
+++ b/lib/modules/Server.js
@@ -73,7 +73,14 @@ export default config => {
         ctx.redirect('/');
       }
     } else {
-      ctx.body = template(state, store);
+      // HEAD request must not have a response body but otherwise
+      // are equivalent to GETs.
+      // HEAD requests are converted into GETS by navigation middleware
+      // if there isn't an explicit HEAD method on our handler.
+      if (ctx.request.method.toLowerCase() !== METHODS.HEAD) {
+        ctx.body = template(state, store);
+      }
+
       ctx.status = state.platform.currentPage.status;
     }
   };

--- a/lib/modules/navigationMiddleware.js
+++ b/lib/modules/navigationMiddleware.js
@@ -38,7 +38,11 @@ const findAndCallHandler = (store, routes, shouldSetPage, data) => {
       [cur.name]: result[index + 1],
     }), {});
 
-    if (shouldSetPage && method === METHODS.GET) {
+    // set page only if its a HEAD or a GET. setting page data is required
+    // to make sure request rendering and redirects work correctly
+    // The only reason HEAD is included is because its the same as GET but
+    // it doesn't have a response body.
+    if (shouldSetPage && (method === METHODS.GET || method === METHODS.HEAD)) {
       dispatch(actions.setPage(pathName, {
         urlParams,
         queryParams,
@@ -57,10 +61,20 @@ const findAndCallHandler = (store, routes, shouldSetPage, data) => {
       getState
     );
 
-    if (h[method] === undefined) {
+    let handlerMethod = method;
+    // HEAD requests are supposed to have the exact same headers and redirects
+    // as a GET request, but they must not send a response body.
+    // To support HEAD requests, we can check if the handler
+    // has a specific HEAD function, otherwise we just use its GET function
+    if (handlerMethod === METHODS.HEAD && !h[METHODS.HEAD]) {
+      handlerMethod = METHODS.GET;
+    }
+
+    if (!h[handlerMethod]) {
       throw new Error(`No method found for ${method.toUpperCase()} ${pathName}`);
     }
-    return h[method].bind(h);
+
+    return h[handlerMethod].bind(h);
   }
 
   throw new Error(`No route found for ${method.toUpperCase()} ${pathName}`);

--- a/lib/modules/router.js
+++ b/lib/modules/router.js
@@ -1,4 +1,5 @@
 export const METHODS = {
+  HEAD: 'head',
   GET: 'get',
   POST: 'post',
   PUT: 'put',


### PR DESCRIPTION
👓  @uzi  @phil303  @nramadas 

Bots and various browsers send HEAD requests before navigating to
urls. Currently, when you send a HEAD request to a platform based
server, and the server crashes. This patch adds implicit support
to the HEAD method for platform Servers. This implicit adding
is easy to do -- HEAD requests by definition, are the same as GETs
except they must not return a response body. Navigation middleware
now checks for a HEAD method on your handler (if you want explicit
control) and then falls back to your handler's GET method.
Server then witholds a response body for HEAD requests.

Testing:

NOTE: by fails I mean you get a stack trace with `No method found for HEAD` and platform tries to redirect you to `/`, which in effect makes any HEAD request try to redirect to `/` -- potentially a redirect loop if there are subsequent HEAD requests to `/` as part of following the redirect.
- [ ] with current node-platform, `curl -I -X HEAD http://localhost:4444` fails
- [ ] with current node-platform, `curl -I -X HEAD http://localhost:4444/u/schwers` fails
- [ ] with this patch, `curl -I X HEAD http://localhost:4444` gives you a 200
- [ ] with this patch, `curl -I X HEAD http://localhost:4444/u/schwers` redirects to `/user/schwers`

To link platform locally you can get around the node module resolution issue by 
- fetch this branch
- build this branch
- copy the js files from the root (in this branch) to your `reddit-mobile` installs `node_modules/@r/platform` directory
