### PR TITLE
Redirect browser on setPage with full url

### DIFF
--- a/lib/modules/actions.js
+++ b/lib/modules/actions.js
@@ -1,3 +1,5 @@
+import URL from 'url';
+
 import { METHODS } from './router';
 
 export const SET_PAGE = 'PLATFORM__SET_PAGE';
@@ -7,10 +9,18 @@ export const NAVIGATE_TO_URL = 'PLATFORM__NAVIGATE_TO_URL';
 export const SET_SHELL = 'PLATFORM__SET_SHELL';
 export const REROUTE_PAGE = 'PLATFORM__REROUTE_PAGE';
 
-export const setPage = (url, { urlParams={}, queryParams={}, hashParams={}, referrer='' }={}) => ({
-  type: SET_PAGE,
-  payload: { url, urlParams, queryParams, hashParams, referrer },
-});
+export const setPage = (url, { urlParams={}, queryParams={}, hashParams={}, referrer='' }={}) => {
+  // if there's a protocol, redirect.
+  const parsedUrl = URL.parse(url);
+  if (parsedUrl.protocol && typeof document !== undefined) {
+    document.location = url;
+  }
+
+  return {
+    type: SET_PAGE,
+    payload: { url, urlParams, queryParams, hashParams, referrer },
+  };
+};
 
 export const gotoPageIndex = (
   pageIndex,


### PR DESCRIPTION
This will cause setPage to do a hard redirect on the client side when receiving links such as https://www.reddit.com/live/abcd. It already works with `ctx.redirect` on the server-side, so no changes there.

👓 @nramadas 
