### PR TITLE
Fix iOS keyboard issue with Form / JSForm

### DIFF
--- a/lib/modules/components.js
+++ b/lib/modules/components.js
@@ -272,6 +272,17 @@ const getValues = form => {
   }, {});
 };
 
+const preventFormSubmit = e => {
+  e.preventDefault();
+
+  // iOS doesn't automatically unfocus form inputs, this leaves the keyboard
+  // open and can create weird states where clicking anything on the page
+  // re-opens the keyboard
+  if (document.activeElement) {
+    document.activeElement.blur();
+  }
+};
+
 export class _Form extends React.Component {
   static propTypes = {
     action: T.string.isRequired,
@@ -287,7 +298,7 @@ export class _Form extends React.Component {
   };
 
   handleSubmit = e => {
-    e.preventDefault();
+    preventFormSubmit(e);
 
     const form = e.target;
     this.props.onSubmit(this.props.action, this.props.method, getValues(form));
@@ -327,7 +338,7 @@ export class JSForm extends React.Component {
   };
 
   handleSubmit = e => {
-    e.preventDefault();
+    preventFormSubmit(e);
     const form = e.target;
     this.props.onSubmit(getValues(form));
   }


### PR DESCRIPTION
To prevent formsubmit we call `e.preventDefault()`, iOS takes this to the extreme and doesn't blur focused inputs or textareas when doing so. This means the keyboard stays up, and in the case of the community search menu on 2X, the keyboard will keep coming up on all subsequent clicks (has something to do with the form being hidden). All of this is fixed by calling `document.activeElement.blur()` to unfocus the active element.

👓  @uzi @nramadas 
