### PR TITLE
Add an agnostic redirect action

### DIFF
--- a/lib/modules/Client.js
+++ b/lib/modules/Client.js
@@ -21,7 +21,7 @@ export default config => {
 
   const well = PromiseWell.create();
   const thunk = Thunker.create();
-  const nav = navigationMiddleware.create(routes, onHandlerComplete);
+  const nav = navigationMiddleware.create(routes, false, onHandlerComplete);
 
   const reds = combineReducers({ ...reducers, platform });
   const wares = reduxMiddleware.concat([nav, thunk, well.middleware]);

--- a/lib/modules/Server.js
+++ b/lib/modules/Server.js
@@ -30,7 +30,7 @@ export default config => {
   const router = new KoaRouter();
 
   const handleRoute = async (ctx, next) => {
-    const nav = navigationMiddleware.create(routes, onHandlerComplete);
+    const nav = navigationMiddleware.create(routes, true, onHandlerComplete);
     const well = PromiseWell.create();
     const thunk = Thunker.create();
 

--- a/lib/modules/actions.js
+++ b/lib/modules/actions.js
@@ -5,7 +5,8 @@ export const SET_STATUS = 'PLATFORM__SET_STATUS';
 export const GOTO_PAGE_INDEX = 'PLATFORM__GOTO_PAGE_INDEX';
 export const NAVIGATE_TO_URL = 'PLATFORM__NAVIGATE_TO_URL';
 export const SET_SHELL = 'PLATFORM__SET_SHELL';
-export const REROUTE_PAGE = 'PLATFORM__REROUTE_PAGE';
+export const REDIRECT = 'PLATFORM__REDIRECT';
+export const REROUTE_PAGE = 'PLATFORM__REROUTE_PAGE'; // re-run the handlers for the page
 
 export const setPage = (url, { urlParams={}, queryParams={}, hashParams={}, referrer='' }={}) => ({
   type: SET_PAGE,
@@ -40,6 +41,8 @@ export const navigateToUrl = (
 });
 
 export const setShell = shell => ({ type: SET_SHELL, shell });
+
+export const redirect = url => ({ type: REDIRECT, url });
 
 export const reroutePage = () => async (dispatch, getState) => {
   const { currentPage } = getState().platform;

--- a/lib/modules/navigationMiddleware.js
+++ b/lib/modules/navigationMiddleware.js
@@ -1,6 +1,7 @@
 import pathToRegex from 'path-to-regexp';
 import { METHODS } from './router';
 import * as actions from './actions';
+import { extractQuery } from './pageUtils';
 
 export function matchRoute(path, routes) {
   let route;
@@ -81,7 +82,7 @@ const findAndCallHandler = (store, routes, shouldSetPage, data) => {
 };
 
 export default {
-  create(routes, onHandlerComplete) {
+  create(routes, isServer, onHandlerComplete) {
     return store => next => action => {
       let shouldSetPage;
       let payload;
@@ -107,7 +108,7 @@ export default {
             const endTime = new Date().getTime();
             const duration = endTime - startTime;
             onHandlerComplete({ meta, startTime, endTime, duration });
-          }
+          };
 
           ret
             .then(timeRoute)
@@ -118,6 +119,39 @@ export default {
 
           return ret;
         }
+
+        case actions.REDIRECT: {
+          const { url } = action;
+
+          // We want to redirect the current page somewhere else.
+          // If we're on the server, this should always translate into a SET_PAGE
+          // action, because we should issue a proper 3XX status code to redirect.
+          if (isServer) {
+            return store.dispatch(actions.setPage(url));
+          }
+
+          if (url.startsWith('/')) {
+            // We have special logic for relative urls:
+            // Before we route, we want to make sure the app's router supports the
+            // path. It's easy to imagine getting a relative url that isn't in
+            // routes, but is valid, e.g. there might be a load-balancer or proxy
+            // that routes the request the appropriate frontend-application based
+            // on varying criteria such as User-Agent, authentication, path, etc
+            const path = url.split('?')[0];
+            const route = matchRoute(path, routes);
+
+            if (route) {
+              const queryParams = extractQuery(url);
+              return store.dispatch(actions.navigateToUrl(METHODS.GET, path, { queryParams }));
+            }
+          }
+
+          // base case for client -- hard redirect via window.location.
+          window.location = url;
+
+          return next(action);
+        }
+
         default: return next(action);
       }
     };


### PR DESCRIPTION
This adds an action to platform, called `redirect`. This action was originally written to handle redirecting to off-site urls so that we could redirect to reddit-live. This seemed awfully similiar to the /u/* -> /user/* redirect handler in mweb, so it seemed appropriate to also handle relative urls (this could be removed, but it seems very useful to have). With support for both absolute and relative urls, with server-friendly redirects this could be the canonical action for changing urls if we wanted it to be.

👓  @nramadas @phil303 