### PR TITLE
Pass a value indicating there is no referrer on initial load

### DIFF
--- a/lib/modules/reducer.js
+++ b/lib/modules/reducer.js
@@ -22,7 +22,8 @@ export default (state=DEFAULT, action={}) => {
     }
 
     case actions.SET_PAGE: {
-      const referrerFromHistory = !isEmpty(state.currentPage)
+      const historyLen = state.history.length;
+      const referrerFromHistory = !isEmpty(state.currentPage) && historyLen > 1
         ? urlFromPage(state.currentPage)
         : '';
 
@@ -31,12 +32,21 @@ export default (state=DEFAULT, action={}) => {
         urlParams,
         queryParams,
         hashParams,
-        referrer=referrerFromHistory,
+        referrer,
         status=200,
       } = action.payload;
 
+      const routeReferrer = referrer ? referrer : referrerFromHistory;
+
       const relevantHistory = state.history.slice(0, state.currentPageIndex + 1);
-      const pageData = { url, urlParams, queryParams, hashParams, referrer, status };
+      const pageData = {
+        url,
+        urlParams,
+        queryParams,
+        hashParams,
+        status,
+        referrer: routeReferrer,
+      };
 
       return {
         ...state,


### PR DESCRIPTION
This relies on the fact that the reroute page action run once.
Allows clients to detect if there is no referrer because user
just navigated there directly vs internal view changes


Although reroutePage is exported it looks like its has a very specific purpose and thus worrying about it being used elsewhere and affecting referrer after initial payload seems very unlikely. I should probably leave a note, or just remove the export. All it is, is a wrapper for dispatching navigateToUrl initially.

